### PR TITLE
change software engineering requirement option from comp 333 to comp 335

### DIFF
--- a/source/bsse.rst
+++ b/source/bsse.rst
@@ -33,7 +33,7 @@ One of the following must be taken:
 
 One of the following must be taken:
 
--   :doc:`comp333`
+-   :doc:`comp335`
 -   :doc:`comp373`
 
 All of the following must be taken:


### PR DESCRIPTION
Needed requirement option for B.S. in Software Engineering to contain COMP 335: Formal Methods in Software Engineering instead of COMP 333: Web Services Programming 