### PR TITLE
mass update to courses, degree info, summer schedule

### DIFF
--- a/source/bscs.rst
+++ b/source/bscs.rst
@@ -32,12 +32,12 @@ One of the following must be taken:
 
 One of the following must be taken:
 
--   :doc:`comp372`
--   :doc:`comp374`
+-   :doc:`comp371`
+-   :doc:`comp310`
 
 All of the following must be taken:
 
--   :doc:`comp163`
+-   :doc:`comp163` or |math201|
 -   :doc:`comp264`
 -   :doc:`comp271`
 -   :doc:`comp313`
@@ -47,18 +47,18 @@ All of the following must be taken:
 Practicum Capstone
 ~~~~~~~~~~~~~~~~~~~
 
-Six (6) credits taken from one or more of :doc:`comp390`, :doc:`comp391`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
+Six (6) credits taken from one or more of :doc:`comp312`, :doc:`comp390`, :doc:`comp391`, :doc:`comp392`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
 
 Electives
 ~~~~~~~~~~
 
 13 Credits taken from:
 
--   :doc:`comp250` or |engl210|
+-   3 credits of |engl210|
 
--   :doc:`isscm349`
+-   Any COMP 300 level electives except :doc:`comp391` and :doc:`comp398`
 
--   Any COMP 300 level electives NOTE: A special case is :doc:`comp390`, :doc:`comp391` and :doc:`comp398` : Three additional units beyond the practicum can be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.
+-   Advanced/Interdisciplinary studies: 7 credits of any COMP 3xx, ISSCM 349:Project Management, MATH 3xx,PHYS 3xx, or STAT 3xx.
 
 Suggested Ordering of Courses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,12 +78,12 @@ Year 2
 
 Year 3
 
--   :doc:`comp372`
+-   :doc:`comp371`
 -   :doc:`comp363`
 -   Electives
 
 Year 4
 
--   :doc:`comp374`
+-   :doc:`comp310`
 -   Electives
 -   Practicum

--- a/source/bscsec.rst
+++ b/source/bscsec.rst
@@ -36,7 +36,7 @@ One of the following must be taken:
 
 All of the following must be taken:
 
--   :doc:`comp163`
+-   :doc:`comp163` or |math201|
 -   :doc:`comp317`
 -   :doc:`comp343`
 -   :doc:`comp347`
@@ -53,17 +53,20 @@ Two courses taken from:
 Practicum Capstone
 ~~~~~~~~~~~~~~~~~~~
 
-Six (6) credits taken from one or more of :doc:`comp390`, :doc:`comp391`, and :doc:`comp398`.  See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
+Six (6) credits taken from one or more of :doc:`comp312`, :doc:`comp390`, :doc:`comp391`, :doc:`comp392`, and :doc:`comp398`.  See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
 
 Electives
 ~~~~~~~~~~
 
 12 credits taken from:
 
--   :doc:`comp250` or |engl210|
--   :doc:`comp264` or :doc:`comp271` NOTE: You must take one of these classes as part of the Major requirements. The second one can be used as an elective if taken.
--   :doc:`isscm349`
--   Any COMP 300 level courses NOTE: A special case is :doc:`comp390`, :doc:`comp391` and :doc:`comp398` : Three additional units beyond the practicum can be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.
+-   3 credits of any COMP course except :doc:`comp391` :doc:`comp398`
+
+-   6 credits from :doc:`comp250` or |engl210|
+    :doc:`comp264` or :doc:`comp271` NOTE: You must take one of these classes as part of the Major requirements. The second one can be used as an elective if taken.
+    Any COMP 3xx level courses except :doc:`comp391` and :doc:`comp398`
+
+-   3 credits of any COMP 3xx level courses or :doc:`isscm349`
 
 
 Suggested Ordering of Courses

--- a/source/bsit.rst
+++ b/source/bsit.rst
@@ -42,7 +42,7 @@ One of the following must be taken:
 
 All of the following must be taken:
 
--   :doc:`comp163`
+-   :doc:`comp163` or |math201|
 -   :doc:`comp300`
 -   :doc:`comp305`
 -   :doc:`comp317`
@@ -52,7 +52,7 @@ All of the following must be taken:
 Practicum Capstone
 ~~~~~~~~~~~~~~~~~~~
 
-Six (6) credits taken from one or more of :doc:`comp390`, :doc:`comp391`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
+Six (6) credits taken from one or more of :doc:`comp312`, :doc:`comp390`, :doc:`comp391`, :doc:`comp392`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
 
 Electives
 ~~~~~~~~~~

--- a/source/bspcs.rst
+++ b/source/bspcs.rst
@@ -1,7 +1,7 @@
-.. index:: b.s. in physics and computer science
-   physics and computer science
+.. index:: b.s. in physics with computer science
+   physics with computer science
 
-B.S. in Physics and Computer Science
+B.S. in Physics with Computer Science
 =====================================
 
 Overview
@@ -27,7 +27,7 @@ Computer Science Requirements
 
 -   :doc:`comp150` (may be replaced by a 300-level classroom elective if :doc:`comp215` is taken)
 -   Introduction to Object-Oriented Programming & Data Structures
-        
+
         -   Either :doc:`comp170`
         -   OR :doc:`comp215`
 
@@ -63,5 +63,3 @@ Physics Requirements
 -   |phys314|
 -   |phys328|
 -   |phys351|
-
-

--- a/source/bsse.rst
+++ b/source/bsse.rst
@@ -36,9 +36,17 @@ One of the following must be taken:
 -   :doc:`comp335`
 -   :doc:`comp373`
 
+One of the following must be taken:
+
+-   :doc:`comp333`
+-   :doc:`comp371`
+-   :doc:`comp373`
+-   :doc:`comp376`
+-   :doc:`comp382`
+
 All of the following must be taken:
 
--   :doc:`comp163`
+-   :doc:`comp163` or |math201|
 -   :doc:`comp271`
 -   :doc:`comp313`
 -   :doc:`comp317`
@@ -47,17 +55,16 @@ All of the following must be taken:
 Practicum Capstone
 ~~~~~~~~~~~~~~~~~~~
 
-Six (6) credits taken from one or more of :doc:`comp390`, :doc:`comp391`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
+Six (6) credits taken from one or more of :doc:`comp312`, :doc:`comp390`, :doc:`comp391`, :doc:`comp392`, and :doc:`comp398`. See the details of registering in the links for each course. (See also individual degree requirements, which generally permit three additional units beyond the practicum to be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.) Students are encouraged to complete these credits during junior and senior years to draw on prior experience.
 
 Electives
 ~~~~~~~~~~
 
 18 credits taken from:
 
--   :doc:`comp250` or |engl210|
--   :doc:`comp264`
--   :doc:`isscm349`
--   Any COMP 300 level electives NOTE: A special case is :doc:`comp390`, :doc:`comp391` and :doc:`comp398` : Three additional units beyond the practicum can be counted as an elective, as long as you take no more than 6 units of 391 and no more than 6 units of 398.
+-   3 credits of any COMP course except :doc:`comp391` and :doc:`comp398`
+-   6 credits from |engl210| or :doc:`comp250`, :doc:`comp264`, and :doc:`comp250` and any COMP 3xx except :doc:`comp391` and :doc:`comp398`
+-   9 credits of any COMP 3xx or :doc:`isscm349`
 
 Suggested Ordering of Courses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +85,7 @@ Year 2
 Year 3
 
 -   :doc:`comp330`
--   :doc:`comp335` or :doc:`comp373`
+-   :doc:`comp335` or :doc:`comp371` or :doc:`comp373` or :doc:`comp376` or :doc:`comp382`
 -   Electives
 
 Year 4

--- a/source/comp310.rst
+++ b/source/comp310.rst
@@ -1,10 +1,10 @@
 .. index:: introduction to operating systems
    operating systems
 
-COMP 374: Introduction to Operating Systems
-=====================================================
+COMP 310 (formerly 374): Introduction to Operating Systems
+==========================================================
 
-This course introduces principles of operating systems and how they are designed.  Various important parts of operating systems such as memory addressing, file structures, processes, and threads are covered. 
+This course introduces principles of operating systems and how they are designed.  Various important parts of operating systems such as memory addressing, file structures, processes, and threads are covered.
 
 Credit Hours
 -------------------
@@ -45,7 +45,7 @@ Students will learn the different parts of an operating system at a functional l
 Syllabi
 ---------------------
 
-.. csv-table:: 
+.. csv-table::
    	:header: "Semester/Year", "Instructor", "URL"
    	:widths: 15, 25, 50
 

--- a/source/comp312.rst
+++ b/source/comp312.rst
@@ -1,8 +1,8 @@
-.. index:: free/open source computing
+.. index:: open source software practicum
    open source
 
-COMP 312: Free/Open Source Computing
-====================================
+COMP 312: Open Source Software Practicum
+========================================
 
 This course will cover the fundamentals of Free and Open Source software development. Topics to be addressed include licensing, Linux, typical software development tools, applications, and techniques for managing remote servers.
 
@@ -24,7 +24,7 @@ development. Topics to be addressed include licensing, Linux, typical
 software development tools (e.g. compilers, scripting languages, build
 tools, and version control software), applications, and techniques for
 managing remote servers. Students will work on a significant
-developmentproject involving free and open-source software and learn how
+development project involving free and open-source software and learn how
 to participate in open-source projects effectively.
 
 Outcome
@@ -35,7 +35,7 @@ Students will learn to implement projects involving Free and Open Source softwar
 Syllabi
 ----------------------
 
-.. csv-table:: 
+.. csv-table::
    	:header: "Semester/Year", "Instructor", "URL"
    	:widths: 15, 25, 50
 

--- a/source/comp371.rst
+++ b/source/comp371.rst
@@ -1,6 +1,6 @@
 .. index:: programming languages
 
-COMP 372: Programming Languages
+COMP 371 (formerly 372): Programming Languages
 ===============================
 
 There are over two thousand programming languages.  This course studies several languages that represent the much smaller number of underlying principles and paradigms.
@@ -33,7 +33,7 @@ programming experience in several representative languages.
 Syllabi
 --------------------
 
-.. csv-table:: 
+.. csv-table::
    	:header: "Semester/Year", "Instructor", "URL"
    	:widths: 15, 25, 50
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -92,6 +92,7 @@ Undergraduate Courses
    comp300
    comp305
    comp309
+   comp310
    comp312
    comp313
    comp314-315
@@ -129,9 +130,8 @@ Undergraduate Courses
    comp367
    comp369
    comp370
-   comp372
+   comp371
    comp373
-   comp374
    comp376
    comp377
    comp378

--- a/source/minorcs.rst
+++ b/source/minorcs.rst
@@ -10,25 +10,25 @@ Computers are extremely pervasive in the modern world, and important connections
 
 (More specifically focused minors are also offered in :doc:`minorit` and :doc:`minorccf`. In addition, majors are offered in the interdisciplinary fields of Bioinformatics, :doc:`bsmcs`, and :doc:`bspcs`, as well as in :doc:`bscs`, :doc:`bscns`, :doc:`bsit`, and :doc:`bsse`.)
 
-Curriculum 
+Curriculum
 ----------
 
 -   :doc:`comp170`
 -   :doc:`comp271`
--   :doc:`comp125` or :doc:`comp150` or :doc:`comp163` or 3 credits of a 300-level COMP course
+-   :doc:`comp125` or :doc:`comp150` or :doc:`comp180` or :doc:`comp163` or 3 credits of a 300-level COMP course
 -   :doc:`comp251` or :doc:`comp264` or 3 credits of a 300-level COMP course
 -   Six (6) units of 300-level Computer Science electives (for instance, two 3-credit courses)
-    
+
     -   Note: :doc:`comp391` is **not** allowed.
-    
+
 Curriculum (pre-Fall 2015)
 """"""""""""""""""""""""""
-    
-If you declared the Computer Science Minor prior to Fall 2015, you may use the old curriculum below.   
+
+If you declared the Computer Science Minor prior to Fall 2015, you may use the old curriculum below.
 
 -   :doc:`comp150`
 -   :doc:`comp170`
 -   :doc:`comp271`
 -   Nine (9) units of Computer Science electives (for instance, three 3-credit courses)
-    
+
     -   Note: 6 units at the 300 level and 3 units at the 200 or 300 level. :doc:`comp391` is **not** allowed.

--- a/source/minorit.rst
+++ b/source/minorit.rst
@@ -14,7 +14,7 @@ Curriculum
 
 Eighteen (18) total credits (or 21 if taking ACCT201 and MGMT201):
 
--   :doc:`comp125` or :doc:`comp150` or :doc:`comp170` or :doc:`comp215`.
+-   :doc:`comp125` or :doc:`comp150` or :doc:`comp170` or :doc:`comp180` or :doc:`comp215`.
 -   :doc:`comp251` or :doc:`comp264` or :doc:`comp271`.
 -   :doc:`comp377` or :doc:`isscm349`.
 -   One of :doc:`comp300`, :doc:`comp305`, :doc:`comp353`, :doc:`comp343`, :doc:`comp345`, :doc:`comp346`, :doc:`comp348`, :doc:`comp349`, :doc:`comp351`, :doc:`comp352`, :doc:`comp340`, :doc:`comp347`.

--- a/source/schedules/summer2018.inc
+++ b/source/schedules/summer2018.inc
@@ -1,9 +1,9 @@
-Summer 2017 Schedule
+Summer 2018 Schedule
 =============================
 
-The CAS has posted the course schedule for Summer 2017. 
+The CAS has posted the course schedule for Summer 2018.
 
-Note that 
+Note that
 Independent Study and Internships can be taken during any session (A, B, or C) with B being the most popular choice as grades are posted later.
 
 The schedule can be found here: http://www.luc.edu/summer/courses/cas/ (scroll down the page to the Computer Science Schedule).

--- a/source/summer.rst
+++ b/source/summer.rst
@@ -1,1 +1,1 @@
-.. include:: schedules/summer2017.inc
+.. include:: schedules/summer2018.inc


### PR DESCRIPTION
Update with these changes:
The title for COMP 312 should be updated to "Open Source Software Practicum".

Two courses that are renumbered as of Fall '18 should start being listed that way on the Department web site in the Course Catalog.
Specifically, 374 is now 310, and 372 is now 371; for now they probably should list as "310 (formerly 374)" and "371 (formerly 372)".
These updates also need to be made in the requirements for the "Computer Science" major and "Software Engineering" major, which
anyway need to get updates along with also "Information Technology" and "Cybersecurity"

The changes for the four majors are indicated in the five attached documents.

Finally, in the "Computer Science" and "Information Technology" *minors*, where it says "COMP 125 ... or COMP 150", we need to add "or COMP 180".
There is no need to maintain an old version of these minors; they can just be changed.

There also is going to be a change for "Physics and Computer Science" to rename it to "Physics with Computer Science" and just link to the Physics web site so we don't have to maintain it separately, but we'll have to wait for Physics to update their web site with the new requirements.
