### PR TITLE
Change in capitalization to fix the hyperlink issue with spring.html

### DIFF
--- a/source/lakeShoreSpring.rst
+++ b/source/lakeShoreSpring.rst
@@ -3,7 +3,7 @@ Spring 2019 Schedule  (Lake Shore)
 ==========================================================================
 
 
-The following courses will (tentatively) be held during the Spring 2018 semester.
+The following courses will (tentatively) be held during the Spring 2019 semester.
 
 For open/full status and latest changes, see
 `LOCUS <http://www.luc.edu/locus>`_.
@@ -24,7 +24,7 @@ Friday line(s) are likely to be isolated makeup days, not every week.
 
 **View Campus Specific Courses below :**
 
-	:doc:`Spring`
+	:doc:`spring`
 
 	:doc:`waterTowerSpring`
 

--- a/source/onlineSpring.rst
+++ b/source/onlineSpring.rst
@@ -3,7 +3,7 @@ Spring 2019 Schedule  (Online)
 ==========================================================================
 
 
-The following courses will (tentatively) be held during the Spring 2018 semester.
+The following courses will (tentatively) be held during the Spring 2019 semester.
 
 For open/full status and latest changes, see
 `LOCUS <http://www.luc.edu/locus>`_.
@@ -28,7 +28,7 @@ Friday line(s) are likely to be isolated makeup days, not every week.
 
 	:doc:`waterTowerSpring`
 
-	:doc:`Spring`
+	:doc:`spring`
 
 
 

--- a/source/spring.rst
+++ b/source/spring.rst
@@ -3,7 +3,7 @@ Spring 2019 Schedule
 ==========================================================================
 
 
-The following courses will (tentatively) be held during the Spring 2018 semester.
+The following courses will (tentatively) be held during the Spring 2019 semester.
 
 For open/full status and latest changes, see
 `LOCUS <http://www.luc.edu/locus>`_.

--- a/source/waterTowerSpring.rst
+++ b/source/waterTowerSpring.rst
@@ -3,7 +3,7 @@ Spring 2019 Schedule  (Water Tower)
 ==========================================================================
 
 
-The following courses will (tentatively) be held during the Spring 2018 semester.
+The following courses will (tentatively) be held during the Spring 2019 semester.
 
 For open/full status and latest changes, see
 `LOCUS <http://www.luc.edu/locus>`_.
@@ -26,7 +26,7 @@ Friday line(s) are likely to be isolated makeup days, not every week.
 
 	:doc:`lakeShoreSpring`
 
-	:doc:`Spring`
+	:doc:`spring`
 
 	:doc:`onlineSpring`
 


### PR DESCRIPTION
changed doc reference to reflect renaming Spring.rst to spring.rst. Also modified page descriptions to reflect the correct year. Works locally and should work on the website if this was a case sensitivity issue.