### PR TITLE
Add "Please see https://www.luc.edu/math/bsmathcs.shtml ." Below the Curriculm Heading of source/undergraduate/bsmcs.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # Other temp files
 *~
+
+# VS Code config folder
+.vscode

--- a/source/undergraduate/bsmcs.rst
+++ b/source/undergraduate/bsmcs.rst
@@ -12,6 +12,8 @@ Many parts of computer science, including scientific computing, analysis of algo
 Curriculum
 -----------
 
+Please see `https://www.luc.edu/math/bsmathcs.shtml <https://www.luc.edu/math/bsmathcs.shtml>`_.
+
 Math Requirements
 ~~~~~~~~~~~~~~~~~~
 
@@ -42,7 +44,7 @@ Two of the following five courses:
 Computer Science Requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--   :doc:`../courses/comp150` (may be replaced by a 300-level classroom elective if :doc:`../courses/comp215` is taken)    
+-   :doc:`../courses/comp150` (may be replaced by a 300-level classroom elective if :doc:`../courses/comp215` is taken)
 -   Introduction to Object-Oriented Programming & Data Structures
 
         -   Either :doc:`../courses/comp170`
@@ -70,6 +72,3 @@ Electives
 ~~~~~~~~~~
 
 -   Any two 300-level, 3-credit courses in Computer Science.
-
-
-

--- a/source/undergraduate/bspcs.rst
+++ b/source/undergraduate/bspcs.rst
@@ -12,6 +12,8 @@ Physics is understood in terms of many mathematical relationships that are much 
 Curriculum
 -----------
 
+Please see `https://www.luc.edu/physics/bs_csphysics.shtml <https://www.luc.edu/physics/bs_csphysics.shtml>`_.
+
 Math Requirements
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added in the string below the Curriculum heading and above the Math Requirments sub-heading.
Made https://www.luc.edu/math/bsmathcs.shtml redirect to https://www.luc.edu/math/bsmathcs.shtml via an inline hyperlink.