### PR TITLE
Update documents to be more maintable

### DIFF
--- a/deprecated/bsitmsit.rst
+++ b/deprecated/bsitmsit.rst
@@ -29,7 +29,7 @@ The academic prerequisites for BA-IT students to be considered for admission to 
     A cumulative GPA of 3.3 or higher for all course work at Loyola;
     Satisfactory progress towards completion of Loyola's core.
 
-Further notes on BA completion: Before the undergraduate deadlines do apply to graduate with your B.A. in the semester you will actually finish! Otherwise you complicate the conversion to graduate status. If the date when you will start graduate status changes from your original application, notify the GPD ahead of time so data in Locus can be fixed.
+Further notes on BA completion: Before the undergraduate deadlines do apply to graduate with your B.A. in the semester you will actually finish! Otherwise you complicate the conversion to graduate status. If the date when you will start graduate status changes from your original application, notify the GPD ahead of time so data in LOCUS can be fixed.
 Application Information
 
 Current Loyola BA-IT students who have met the above academic prerequisites are encouraged to apply . Students who have an interest in the program are encouraged to consult with the Graduate Program Director (GPD) for Information Technology, Dr. Peter Lars Dordal, in the semester prior to their application. The application will be evaluated upon completion of the following:

--- a/deprecated/comp372.rst
+++ b/deprecated/comp372.rst
@@ -8,4 +8,4 @@ See :doc:`../courses/comp371`. COMP 372 is now COMP 371.
 Syllabi
 --------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/deprecated/comp372.rst
+++ b/deprecated/comp372.rst
@@ -1,7 +1,7 @@
 .. index:: programming languages
 
 COMP 372: Programming languages
-==========================
+===============================
 
 See :doc:`../courses/comp371`. COMP 372 is now COMP 371.
 

--- a/deprecated/comp411.rst
+++ b/deprecated/comp411.rst
@@ -22,4 +22,4 @@ System administration is an essential ingredient of modern computing practice. K
 Syllabi
 ----------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/deprecated/comp470.rst
+++ b/deprecated/comp470.rst
@@ -28,4 +28,4 @@ to large data sets to make inferences for prediction or decision making.
 Syllabi
 ----------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/deprecated/cuneoFall.rst
+++ b/deprecated/cuneoFall.rst
@@ -15,9 +15,9 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 

--- a/deprecated/fall.rst
+++ b/deprecated/fall.rst
@@ -1,5 +1,5 @@
 
-Fall 2018 Schedule 
+Fall 2018 Schedule
 ==========================================================================
 Updated 08/24/2018 13:53:05
 
@@ -15,14 +15,14 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_`. 
+:ref:`fall_graduate_courses_list_`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`waterTowerFall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp111` 
+:doc:`../courses/comp111`
     | Section 001 (6721) Credits: 3; In person; Lecture
     | Instructor: David B Dennis
     | Crown Center:141 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -50,7 +50,7 @@ Undergraduate Courses
     Taught in a blended format, this course will involve independent study of online lectures combined with in-class discussion of these materials.
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 001 (3043) Credits: 3; In person; Laboratory
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Thursday 06:30PM-09:00
@@ -60,7 +60,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 002 (5341) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Sullivan Center:253 (Lake Shore) Tuesday 06:00PM-08:30
@@ -70,7 +70,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 001 (3044) Credits: 3; In person; Lecture
     | Instructor: John Nikolas O'Sullivan
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
@@ -80,18 +80,18 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 002 (3045) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
 
     **Notes:** Combined Section ID:
-    
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 003 (3046) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -101,7 +101,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 004 (6148) Credits: 3; In person; Lecture
     | Instructor: William Honig
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -120,7 +120,7 @@ Undergraduate Courses
     This class is restricted to dual credit high school students from Riverside-Brookfield High School
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 003 (4867) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -128,14 +128,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 004 (6749) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Mundelein Center:0519 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -143,14 +143,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 005 (6750) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 04:15PM-05:30
@@ -158,14 +158,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 001/01L (3048) Credits: 3; In person; Lecture/Lab
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -174,18 +174,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-001 (Lecture) will be automatically enrolled in COMP 170-01L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 002/02L (3049) Credits: 3; In person; Lecture/Lab
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -194,18 +194,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-002 (Lecture) will be automatically enrolled in COMP 170-02L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 003/03L (6367) Credits: 3; In person; Lecture/Lab
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -214,18 +214,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 004/04L (3556) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -234,13 +234,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP
     170 should contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -254,18 +254,18 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science I.  Eight Week-First Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent is required, and then a Computer Science Department staff member will
     enroll you.
-    
-    
-    
+
+
+
     COMP 170-400 meets on Mondays, 4:15 pm - 8:15 pm, for the first eight weeks of the Semester, replacing holiday/vacation Mondays with Fridays.  So the
     Monday/Friday class schedule is: Mon, Aug 27; Fri, Sept 7; Mon, Sept 10; Mon, Sept 17; Mon, Sept 24; Mon, Oct 1; Fri, Oct 12; and Mon, Oct 15.
-    
-    
+
+
     Labs meet on consecutive Thursdays, 4:15 pm - 6:30 pm: Thurs, Aug 30 through Thurs, Oct 18.
 
 
@@ -310,7 +310,7 @@ Undergraduate Courses
     This class is restricted to Dual-Credit (High School) students.
 
 
-:doc:`../courses/comp180` 
+:doc:`../courses/comp180`
     | Section 001 (6282) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -318,7 +318,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp215` 
+:doc:`../courses/comp215`
     | Section 001 (3071) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Crown Center:105 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -327,30 +327,30 @@ Undergraduate Courses
     COMP 215 is crosslisted with MATH 215. Register for MATH 215.
 
 
-:doc:`../courses/comp250` 
+:doc:`../courses/comp250`
     | Section 01W (3197) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Mundelein Center:0303 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     *This is a writing intensive course.*
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp251` 
+:doc:`../courses/comp251`
     | Section 001 (3141) Credits: 3; In person; Lecture
     | Instructor: Guy Bevente
     | Cuneo Hall:117 (Lake Shore) Monday 07:00PM-09:30
 
     **Notes:**
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
@@ -365,24 +365,24 @@ Undergraduate Courses
     COMP 251-700N is an online section. Required synchronous sessions will be held Tuesdays 6-9PM CST
 
 
-:doc:`../courses/comp264` 
+:doc:`../courses/comp264`
     | Section 001 (3373) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 001 (6371) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:05
@@ -392,7 +392,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 002/02L (3374) Credits: 3; In person; Lecture/Lab
     | Instructor: Konstantin Laufer
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -401,13 +401,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-002 (Lecture) will be automatically enrolled in COMP 271-02L (Lab).
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 003/03L (6372) Credits: 3; In person; Lecture/Lab
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -416,9 +416,9 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-003 (Lecture) will be automatically enrolled in COMP 271-03L (Lab).
 
 
@@ -430,9 +430,9 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science II.  Eight Week-Second Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent required, and then a Computer Science Department staff member will
     enroll you.
 
@@ -449,7 +449,7 @@ Undergraduate Courses
     COMP 271-700N is an online section. Required synchronous sessions will be held Thursdays 6-9PM CST and one session Friday 11/30 for holiday make-up class.
 
 
-:doc:`../courses/comp309` 
+:doc:`../courses/comp309`
     | Section 001 (6733) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -457,7 +457,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp310` 
+:doc:`../courses/comp310`
     | Section 001 (6322) Credits: 3; In person; Lecture
     | Instructor: Benjamin Gonzalez
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -466,7 +466,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`../courses/comp313` 
+:doc:`../courses/comp313`
     | Section 001 (3464) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:203 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -476,7 +476,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp313` 
+:doc:`../courses/comp313`
     | Section 002 (6760) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -504,7 +504,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Andrew Harrington (aharrin@luc.edu) beforehand, if you cannot attend, or if you have any questions.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 001 (3051) Credits: 3; Online; Lecture
     | Instructor: Matthew Paul Butcher
     | Online Times: TBA
@@ -512,27 +512,27 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     **Notes:**
     This is an online, asynchronous class.  All lectures will be pre-recorded.  Students are asked to attend smaller-group online interactive discussions at
     regular intervals during the semester, with possible times chosen to fit different groups' schedules.
-    
-    
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 02W (6284) Credits: 3; In person; Lecture
     | Instructor: Nicoletta C. Ruane
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday 04:15PM-05:30
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp322` 
+:doc:`../courses/comp322`
     | Section 001 (6285) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -541,7 +541,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 422-001.
 
 
-:doc:`../courses/comp324` 
+:doc:`../courses/comp324`
     | Section 001 (6286) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -550,7 +550,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 424-001.
 
 
-:doc:`../courses/comp325` 
+:doc:`../courses/comp325`
     | Section 001 (6287) Credits: 3; Hybrid; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -559,7 +559,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 425-001
 
 
-:doc:`../courses/comp330` 
+:doc:`../courses/comp330`
     | Section 001 (4877) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:104 (Lake Shore) Friday 09:20AM-10:10
@@ -568,7 +568,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     This is a hybrid class.  More details will be forthcoming.
 
 
-:doc:`../courses/comp333` 
+:doc:`../courses/comp333`
     | Section 001 (6288) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -577,7 +577,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 433-001.
 
 
-:doc:`../courses/comp336` 
+:doc:`../courses/comp336`
     | Section 001 (6289) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -586,19 +586,19 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 436-001.
 
 
-:doc:`../courses/comp340` 
+:doc:`../courses/comp340`
     | Section 001 (6350) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 488-340.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 001 (6290) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -607,7 +607,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 443-001.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 002 (6291) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -615,12 +615,12 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 443-002.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 001 (6292) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -629,7 +629,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 447-001.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 002 (6293) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -637,13 +637,13 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 447-002.
 
 
-:doc:`../courses/comp363` 
+:doc:`../courses/comp363`
     | Section 001 (3061) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -653,19 +653,19 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     graduate advisor.
 
 
-:doc:`../courses/comp364` 
+:doc:`../courses/comp364`
     | Section 001 (6294) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 464-001.
 
 
-:doc:`../courses/comp371` 
+:doc:`../courses/comp371`
     | Section 001 (6323) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -674,7 +674,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 471-001.
 
 
-:doc:`../courses/comp377` 
+:doc:`../courses/comp377`
     | Section 001 (6324) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45
@@ -683,7 +683,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 477-001.
 
 
-:doc:`../courses/comp379` 
+:doc:`../courses/comp379`
     | Section 001 (6325) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -692,17 +692,17 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 479-001.
 
 
-:doc:`../courses/comp381` 
+:doc:`../courses/comp381`
     | Section 001 (3742) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:** Combined Section ID:
-    
+
     COMP 381-001 is combined with BIOL 388-001.  Register for BIOL 388-001 (1934).  Also, combined with COMP 488-381 and BIOL 488-001.
 
 
-:doc:`../courses/comp386` 
+:doc:`../courses/comp386`
     | Section 001 (6326) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -711,25 +711,25 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Combined with COMP 488-386.
 
 
-:doc:`../courses/comp390` 
+:doc:`../courses/comp390`
     | Section 01E (3466) Credits: 1 - 3; Online; Lecture
     | Instructor: Ronald I Greenberg
     | Online Times: TBA
 
     **Notes:**
     Broadening Participation in STEM (Computing, Mathematics, and Science).
-    
-    
+
+
     This class is online and fully asynchronous, but students must complete service learning activities in-person at a site of their choosing to be approved by
     the instructor in accord with the course design.  To complete the full course (incorporating at least 25 hours of service and other requirements) in one
     semester, register for 3 credits; to spread over two semesters, register for 1 or 2 credits in the first semester (requiring 6 or 14 service hours in the
     first semester, respectively).
-    
-    
+
+
     This class satisfies the Engaged Learning requirement in the Service Learning category.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 01E (2085) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -739,7 +739,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     staff member will enroll you.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 02E (4918) Credits: 1 - 6; Online; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Online Times: TBA
@@ -749,18 +749,18 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     Computer Science Department staff member will enroll you.
 
 
-:doc:`../courses/comp392` 
+:doc:`../courses/comp392`
     | Section 01E (4887) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:** Combined Section ID:
-    
+
     This class satisfies the Engaged Learning requirement in the Undergraduate Research category.
     Instructor Consent Required.
-    
-    
-    
+
+
+
     Combined with COMP 488-392 and BIOL 392-001.
 
 
@@ -772,7 +772,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`../courses/comp399` 
+:doc:`../courses/comp399`
     | Section 001 (4883) Credits: 1; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:15PM-05:30
@@ -780,7 +780,7 @@ COMP 315  (Description: :doc:`../courses/comp314-315`)
 
 
 
-:doc:`../courses/comp399` 
+:doc:`../courses/comp399`
     | Section 500 (6328) Credits: 1; In person; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:117 (Lake Shore) Friday 02:45PM-04:00
@@ -796,7 +796,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp403` 
+:doc:`../courses/comp403`
     | Section 001 (6329) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Corboy Law Center:0423 (Water Tower) Wednesday 07:00PM-09:30
@@ -804,7 +804,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp409` 
+:doc:`../courses/comp409`
     | Section 001 (6732) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -812,7 +812,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp410` 
+:doc:`../courses/comp410`
     | Section 001 (6330) Credits: 3; In person; Lecture
     | Instructor: Benjamin Gonzalez
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -821,7 +821,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`../courses/comp413` 
+:doc:`../courses/comp413`
     | Section 001 (3465) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -829,7 +829,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp417` 
+:doc:`../courses/comp417`
     | Section 001 (3052) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Mundelein Center:0303 (Lake Shore) Wednesday 04:15PM-06:45
@@ -837,7 +837,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp422` 
+:doc:`../courses/comp422`
     | Section 001 (6331) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -846,7 +846,7 @@ Graduate Courses
     Combined with COMP 322-001.
 
 
-:doc:`../courses/comp424` 
+:doc:`../courses/comp424`
     | Section 001 (6377) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -855,7 +855,7 @@ Graduate Courses
     Combined with COMP 324-001.
 
 
-:doc:`../courses/comp425` 
+:doc:`../courses/comp425`
     | Section 001 (6339) Credits: 3; Hybrid; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -864,7 +864,7 @@ Graduate Courses
     Combined with COMP 325-001
 
 
-:doc:`../courses/comp433` 
+:doc:`../courses/comp433`
     | Section 001 (6340) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -873,7 +873,7 @@ Graduate Courses
     Combined with COMP 333-001.
 
 
-:doc:`../courses/comp436` 
+:doc:`../courses/comp436`
     | Section 001 (6341) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -882,7 +882,7 @@ Graduate Courses
     Combined with COMP 336-001.
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 001 (6342) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -891,7 +891,7 @@ Graduate Courses
     Combined with COMP 343-001.
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 002 (6349) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -899,12 +899,12 @@ Graduate Courses
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 343-002.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 001 (6358) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -913,7 +913,7 @@ Graduate Courses
     Combined with COMP 347-001.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 002 (6359) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -921,13 +921,13 @@ Graduate Courses
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 347-002.
 
 
-:doc:`../courses/comp453` 
+:doc:`../courses/comp453`
     | Section 001 (3064) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:203 (Lake Shore) Thursday 04:15PM-06:45
@@ -939,19 +939,19 @@ Graduate Courses
     well as the MongoDB query language.  We will use Jupyter Notebooks for interactive testing, MongoDB Atlas as a cloud-based host, and Compass as a local GUI.
 
 
-:doc:`../courses/comp464` 
+:doc:`../courses/comp464`
     | Section 001 (6361) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 364-001.
 
 
-:doc:`../courses/comp471` 
+:doc:`../courses/comp471`
     | Section 001 (6366) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -960,7 +960,7 @@ Graduate Courses
     Combined with COMP 371-001.
 
 
-:doc:`../courses/comp477` 
+:doc:`../courses/comp477`
     | Section 001 (6362) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45
@@ -969,7 +969,7 @@ Graduate Courses
     Combined with COMP 377-001.
 
 
-:doc:`../courses/comp479` 
+:doc:`../courses/comp479`
     | Section 001 (6363) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -979,7 +979,7 @@ Graduate Courses
 
 
 
-COMP 488 Topic: Comp Forensics Investigations 
+COMP 488 Topic: Comp Forensics Investigations
     | Section 340 (6351) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
@@ -987,23 +987,23 @@ COMP 488 Topic: Comp Forensics Investigations
 
     **Notes:**
     Computer Forensics.
-    
-    
-    
+
+
+
     Prerequisites: COMP 170 (or equivalent) and ( COMP 417 or COMP 443 )
-    
-    
-    
-    
-    
+
+
+
+
+
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 340-001.
 
 
 
-COMP 488 Topic: Bioinformatics 
+COMP 488 Topic: Bioinformatics
     | Section 381 (4215) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -1011,23 +1011,23 @@ COMP 488 Topic: Bioinformatics
 
     **Notes:**
     Bioinformatics
-    
-    
-    
+
+
+
     Prerequisite: BIOL 101: General Biology I (or equivalent)
-    
-    
-    
+
+
+
     Students will engage in the applications of computer-based tools and database searching to better understand DNA and protein structure, function, and
     evolution. Students will be able to apply their understanding of genetic and evolutionary processes to the appropriate use of computer software and
     manipulation of large databases to accurately predict structural, informational, functional, and evolutionary characteristics of DNA and protein sequences.
-    
-    
+
+
     Combined with COMP 381-001, BIOL 388-001, and BIOL 488-001
 
 
 
-COMP 488 Topic: Computational Neurosci 
+COMP 488 Topic: Computational Neurosci
     | Section 386 (6365) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -1035,24 +1035,24 @@ COMP 488 Topic: Computational Neurosci
 
     **Notes:**
     Computational Neuroscience
-    
-    
-    
+
+
+
     Prerequisite: COMP 150 OR 170
-    
-    
-    
+
+
+
     Introduces computational methods to understand neural processing in the brain. Levels of representation from low-level, temporally precise neural circuits
     to systems-level rate-encoded models, to information-theoretic approaches. Emphasis on sensory systems, primarily vision and audition, most readily
     demonstrating the need for such computational techniques.
-    
-    
-    
+
+
+
     Combined with COMP 386-001.
 
 
 
-COMP 488 Topic: Metagenomics 
+COMP 488 Topic: Metagenomics
     | Section 392 (4888) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
@@ -1060,17 +1060,17 @@ COMP 488 Topic: Metagenomics
 
     **Notes:**
     Metagenomics
-    
-    
-    
+
+
+
     Prerequisite: Instructor Consent
-    
-    
-    
+
+
+
     Exploration of next-generation sequencing technologies for assessing microbial diversity in ecological niches. Students will gain hands-on experience with
     metagenomic methodologies while working in an interdisciplinary, collaborative setting.
-    
-    
+
+
     Combined with COMP 392-01E and BIOL 392-001
 
 
@@ -1082,7 +1082,7 @@ COMP 488 Topic: Metagenomics
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 001 (2094) Credits: 1 - 6; In person; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA
@@ -1091,7 +1091,7 @@ COMP 488 Topic: Metagenomics
     This course involves an internship experience.  Department Consent required, and then a Computer Science Department staff member will enroll you.
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 002 (4919) Credits: 1 - 6; Online; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Online Times: TBA
@@ -1101,7 +1101,7 @@ COMP 488 Topic: Metagenomics
     will enroll you.
 
 
-:doc:`../courses/comp605` 
+:doc:`../courses/comp605`
     | Section 001 (2902) Credits: 0; In person; FTC-Supervision
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/lakeShoreFall.rst
+++ b/deprecated/lakeShoreFall.rst
@@ -15,14 +15,14 @@ TextBook information to be updated soon.
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Lake Shore`. 
+:ref:`fall_graduate_courses_list_Lake Shore`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`waterTowerFall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp111` 
+:doc:`comp111`
     | Section 001 (6721) Credits: 3; In person; Lecture
     | Instructor: David B Dennis
     | Crown Center:141 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -51,7 +51,7 @@ Undergraduate Courses
     term papers are required.
 
 
-:doc:`comp122` 
+:doc:`comp122`
     | Section 001 (6147) Credits: 3; In person; Lecture
     | Instructor: David Wetzel
     | Place TBA (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -59,7 +59,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 001 (3043) Credits: 3; In person; Laboratory
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Thursday 06:30PM-09:00
@@ -69,7 +69,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 002 (5341) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Sullivan Center:253 (Lake Shore) Tuesday 06:00PM-08:30
@@ -79,7 +79,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 001 (3044) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
@@ -89,7 +89,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 002 (3045) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
@@ -99,7 +99,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 003 (3046) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -109,7 +109,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 004 (6148) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -119,7 +119,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 003 (4867) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -127,14 +127,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 004 (6749) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Mundelein Center:0519 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -142,7 +142,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 005 (6750) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 04:15PM-05:30
@@ -150,7 +150,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 001/01L (3048) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -159,18 +159,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-001 (Lecture) will be automatically enrolled in COMP 170-01L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 002/02L (3049) Credits: 3; In person; Lecture/Lab
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -179,18 +179,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-002 (Lecture) will be automatically enrolled in COMP 170-02L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 003/03L (6367) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -199,18 +199,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 004/04L (3556) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -219,13 +219,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP
     170 should contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -239,22 +239,22 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science I.  Eight Week-First Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent is required, and then a Computer Science Department staff member will
     enroll you.
-    
-    
-    
+
+
+
     COMP 170-400 meets on Mondays, 4:15 pm - 8:15 pm, for the first eight weeks of the Semester, replacing holiday/vacation Mondays with Fridays.  So the
     Monday/Friday class schedule is: Mon, Aug 27; Fri, Sept 7; Mon, Sept 10; Mon, Sept 17; Mon, Sept 24; Mon, Oct 1; Fri, Oct 12; and Mon, Oct 15.
-    
-    
+
+
     Labs meet on consecutive Thursdays, 4:15 pm - 6:30 pm: Thurs, Aug 30 through Thurs, Oct 18.
 
 
-:doc:`comp180` 
+:doc:`comp180`
     | Section 001 (6282) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -262,7 +262,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp215` 
+:doc:`comp215`
     | Section 001 (3071) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Crown Center:105 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -271,51 +271,51 @@ Undergraduate Courses
     COMP 215 is crosslisted with MATH 215. Register for MATH 215.
 
 
-:doc:`comp250` 
+:doc:`comp250`
     | Section 01W (3197) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Life Science Buildin:212 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     *This is a writing intensive course.*
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp251` 
+:doc:`comp251`
     | Section 001 (3141) Credits: 3; In person; Lecture
     | Instructor: Guy Bevente
     | Cuneo Hall:117 (Lake Shore) Monday 07:00PM-09:30
 
     **Notes:**
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp264` 
+:doc:`comp264`
     | Section 001 (3373) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 001 (6371) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:05
@@ -325,7 +325,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 002/02L (3374) Credits: 3; In person; Lecture/Lab
     | Instructor: Konstantin Laufer
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -334,13 +334,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-002 (Lecture) will be automatically enrolled in COMP 271-02L (Lab).
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 003/03L (6372) Credits: 3; In person; Lecture/Lab
     | Instructor: Mark Albert
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -349,9 +349,9 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-003 (Lecture) will be automatically enrolled in COMP 271-03L (Lab).
 
 
@@ -363,14 +363,14 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science II.  Eight Week-Second Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent required, and then a Computer Science Department staff member will
     enroll you.
 
 
-:doc:`comp309` 
+:doc:`comp309`
     | Section 001 (6733) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -378,7 +378,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp310` 
+:doc:`comp310`
     | Section 001 (6322) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -387,7 +387,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 001 (3464) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:203 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -397,7 +397,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 002 (6760) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -425,21 +425,21 @@ COMP 315  (Description: :doc:`comp314-315`)
     Harrington (aharrin@luc.edu) beforehand if you cannot attend, or if you have any questions.
 
 
-:doc:`comp317` 
+:doc:`comp317`
     | Section 02W (6284) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday 04:15PM-05:30
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp322` 
+:doc:`comp322`
     | Section 001 (6285) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -448,7 +448,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 422-001.
 
 
-:doc:`comp325` 
+:doc:`comp325`
     | Section 001 (6287) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -457,7 +457,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 425-001
 
 
-:doc:`comp330` 
+:doc:`comp330`
     | Section 001 (4877) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:104 (Lake Shore) Friday 09:20AM-10:10
@@ -466,7 +466,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     This is a hybrid class.  More details will be forthcoming.
 
 
-:doc:`comp363` 
+:doc:`comp363`
     | Section 001 (3061) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -476,7 +476,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     graduate advisor.
 
 
-:doc:`comp366` 
+:doc:`comp366`
     | Section 001 (6295) Credits: 3; In person; Laboratory
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -485,7 +485,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 450-001.
 
 
-:doc:`comp371` 
+:doc:`comp371`
     | Section 001 (6323) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -494,7 +494,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 471-001.
 
 
-:doc:`comp379` 
+:doc:`comp379`
     | Section 001 (6325) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -503,17 +503,17 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 479-001.
 
 
-:doc:`comp381` 
+:doc:`comp381`
     | Section 001 (3742) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:** Combined Section ID:
-    
+
     COMP 381-001 is combined with BIOL 388-001.  Register for BIOL 388-001 (1934).  Also, combined with COMP 488-381 and BIOL 488-001.
 
 
-:doc:`comp386` 
+:doc:`comp386`
     | Section 001 (6326) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -522,7 +522,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 488-386.
 
 
-:doc:`comp391` 
+:doc:`comp391`
     | Section 01E (2085) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -532,18 +532,18 @@ COMP 315  (Description: :doc:`comp314-315`)
     staff member will enroll you.
 
 
-:doc:`comp392` 
+:doc:`comp392`
     | Section 01E (4887) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:** Combined Section ID:
-    
+
     This class satisfies the Engaged Learning requirement in the Undergraduate Research category.
     Instructor Consent Required.
-    
-    
-    
+
+
+
     Combined with COMP 488-392 and BIOL 392-001.
 
 
@@ -555,7 +555,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 001 (4883) Credits: 1; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:15PM-05:30
@@ -563,7 +563,7 @@ COMP 315  (Description: :doc:`comp314-315`)
 
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 500 (6328) Credits: 1; In person; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:117 (Lake Shore) Friday 02:45PM-04:00
@@ -579,7 +579,7 @@ Graduate Courses
 
 
 
-:doc:`comp409` 
+:doc:`comp409`
     | Section 001 (6732) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -587,7 +587,7 @@ Graduate Courses
 
 
 
-:doc:`comp410` 
+:doc:`comp410`
     | Section 001 (6330) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -596,7 +596,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`comp413` 
+:doc:`comp413`
     | Section 001 (3465) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -604,7 +604,7 @@ Graduate Courses
 
 
 
-:doc:`comp417` 
+:doc:`comp417`
     | Section 001 (3052) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Cuneo Hall:003 (Lake Shore) Wednesday 04:15PM-06:45
@@ -612,7 +612,7 @@ Graduate Courses
 
 
 
-:doc:`comp422` 
+:doc:`comp422`
     | Section 001 (6331) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -621,7 +621,7 @@ Graduate Courses
     Combined with COMP 322-001.
 
 
-:doc:`comp425` 
+:doc:`comp425`
     | Section 001 (6339) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -630,7 +630,7 @@ Graduate Courses
     Combined with COMP 325-001
 
 
-:doc:`comp450` 
+:doc:`comp450`
     | Section 001 (6360) Credits: 3; In person; Lecture
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -639,20 +639,20 @@ Graduate Courses
     Combined with COMP 366-001.
 
 
-:doc:`comp453` 
+:doc:`comp453`
     | Section 001 (3064) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:203 (Lake Shore) Thursday 04:15PM-06:45
 
     **Notes:**
     This section of COMP 453 will cover advanced concepts in database access and programming, including SQL, using MySQL and PHP for the project.
-    
-    
+
+
     Outcome: Students will learn application development using the latest software tools.  Students will also learn techniques for web based data retrieval and
     manipulation.
 
 
-:doc:`comp471` 
+:doc:`comp471`
     | Section 001 (6366) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -661,7 +661,7 @@ Graduate Courses
     Combined with COMP 371-001.
 
 
-:doc:`comp479` 
+:doc:`comp479`
     | Section 001 (6363) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -671,7 +671,7 @@ Graduate Courses
 
 
 
-COMP 488 Topic: Bioinformatics 
+COMP 488 Topic: Bioinformatics
     | Section 381 (4215) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -679,23 +679,23 @@ COMP 488 Topic: Bioinformatics
 
     **Notes:**
     Bioinformatics
-    
-    
-    
+
+
+
     Prerequisite: BIOL 101: General Biology I (or equivalent)
-    
-    
-    
+
+
+
     Students will engage in the applications of computer-based tools and database searching to better understand DNA and protein structure, function, and
     evolution. Students will be able to apply their understanding of genetic and evolutionary processes to the appropriate use of computer software and
     manipulation of large databases to accurately predict structural, informational, functional, and evolutionary characteristics of DNA and protein sequences.
-    
-    
+
+
     Combined with COMP 381-001, BIOL 388-001, and BIOL 488-001
 
 
 
-COMP 488 Topic: Computational Neurosci 
+COMP 488 Topic: Computational Neurosci
     | Section 386 (6365) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -703,24 +703,24 @@ COMP 488 Topic: Computational Neurosci
 
     **Notes:**
     Computational Neuroscience
-    
-    
-    
+
+
+
     Prerequisite: COMP 150 OR 170
-    
-    
-    
+
+
+
     Introduces computational methods to understand neural processing in the brain. Levels of representation from low-level, temporally precise neural circuits
     to systems-level rate-encoded models, to information-theoretic approaches. Emphasis on sensory systems, primarily vision and audition, most readily
     demonstrating the need for such computational techniques.
-    
-    
-    
+
+
+
     Combined with COMP 386-001.
 
 
 
-COMP 488 Topic: Metagenomics 
+COMP 488 Topic: Metagenomics
     | Section 392 (4888) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
@@ -728,17 +728,17 @@ COMP 488 Topic: Metagenomics
 
     **Notes:**
     Metagenomics
-    
-    
-    
+
+
+
     Prerequisite: Instructor Consent
-    
-    
-    
+
+
+
     Exploration of next-generation sequencing technologies for assessing microbial diversity in ecological niches. Students will gain hands-on experience with
     metagenomic methodologies while working in an interdisciplinary, collaborative setting.
-    
-    
+
+
     Combined with COMP 392-01E and BIOL 392-001
 
 
@@ -750,7 +750,7 @@ COMP 488 Topic: Metagenomics
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp499` 
+:doc:`comp499`
     | Section 001 (2094) Credits: 1 - 6; In person; Independent Study
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA
@@ -759,7 +759,7 @@ COMP 488 Topic: Metagenomics
     This course involves an internship experience.  Department Consent required, and then a Computer Science Department staff member will enroll you.
 
 
-:doc:`comp605` 
+:doc:`comp605`
     | Section 001 (2902) Credits: 0; In person; FTC-Supervision
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/lakeShorefall.rst
+++ b/deprecated/lakeShorefall.rst
@@ -15,14 +15,14 @@ TextBook information to be updated soon.
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Lake Shore`. 
+:ref:`fall_graduate_courses_list_Lake Shore`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`waterTowerFall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp111` 
+:doc:`comp111`
     | Section 001 (6721) Credits: 3; In person; Lecture
     | Instructor: David B Dennis
     | Crown Center:141 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -51,7 +51,7 @@ Undergraduate Courses
     term papers are required.
 
 
-:doc:`comp122` 
+:doc:`comp122`
     | Section 001 (6147) Credits: 3; In person; Lecture
     | Instructor: David Wetzel
     | Place TBA (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -59,7 +59,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 001 (3043) Credits: 3; In person; Laboratory
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Thursday 06:30PM-09:00
@@ -69,7 +69,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 002 (5341) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Sullivan Center:253 (Lake Shore) Tuesday 06:00PM-08:30
@@ -79,7 +79,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 001 (3044) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
@@ -89,7 +89,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 002 (3045) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
@@ -99,7 +99,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 003 (3046) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -109,7 +109,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 004 (6148) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -119,7 +119,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 003 (4867) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -127,14 +127,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 004 (6749) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Mundelein Center:0519 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -142,7 +142,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 005 (6750) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 04:15PM-05:30
@@ -150,7 +150,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 001/01L (3048) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -159,18 +159,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-001 (Lecture) will be automatically enrolled in COMP 170-01L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 002/02L (3049) Credits: 3; In person; Lecture/Lab
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -179,18 +179,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-002 (Lecture) will be automatically enrolled in COMP 170-02L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 003/03L (6367) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -199,18 +199,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 004/04L (3556) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -219,13 +219,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP
     170 should contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -239,22 +239,22 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science I.  Eight Week-First Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent is required, and then a Computer Science Department staff member will
     enroll you.
-    
-    
-    
+
+
+
     COMP 170-400 meets on Mondays, 4:15 pm - 8:15 pm, for the first eight weeks of the Semester, replacing holiday/vacation Mondays with Fridays.  So the
     Monday/Friday class schedule is: Mon, Aug 27; Fri, Sept 7; Mon, Sept 10; Mon, Sept 17; Mon, Sept 24; Mon, Oct 1; Fri, Oct 12; and Mon, Oct 15.
-    
-    
+
+
     Labs meet on consecutive Thursdays, 4:15 pm - 6:30 pm: Thurs, Aug 30 through Thurs, Oct 18.
 
 
-:doc:`comp180` 
+:doc:`comp180`
     | Section 001 (6282) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -262,7 +262,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp215` 
+:doc:`comp215`
     | Section 001 (3071) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Crown Center:105 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -271,51 +271,51 @@ Undergraduate Courses
     COMP 215 is crosslisted with MATH 215. Register for MATH 215.
 
 
-:doc:`comp250` 
+:doc:`comp250`
     | Section 01W (3197) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Life Science Buildin:212 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     *This is a writing intensive course.*
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp251` 
+:doc:`comp251`
     | Section 001 (3141) Credits: 3; In person; Lecture
     | Instructor: Guy Bevente
     | Cuneo Hall:117 (Lake Shore) Monday 07:00PM-09:30
 
     **Notes:**
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp264` 
+:doc:`comp264`
     | Section 001 (3373) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 001 (6371) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:05
@@ -325,7 +325,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 002/02L (3374) Credits: 3; In person; Lecture/Lab
     | Instructor: Konstantin Laufer
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -334,13 +334,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-002 (Lecture) will be automatically enrolled in COMP 271-02L (Lab).
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 003/03L (6372) Credits: 3; In person; Lecture/Lab
     | Instructor: Mark Albert
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -349,9 +349,9 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-003 (Lecture) will be automatically enrolled in COMP 271-03L (Lab).
 
 
@@ -363,14 +363,14 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science II.  Eight Week-Second Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent required, and then a Computer Science Department staff member will
     enroll you.
 
 
-:doc:`comp309` 
+:doc:`comp309`
     | Section 001 (6733) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -378,7 +378,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp310` 
+:doc:`comp310`
     | Section 001 (6322) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -387,7 +387,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 001 (3464) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:203 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -397,7 +397,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 002 (6760) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -425,21 +425,21 @@ COMP 315  (Description: :doc:`comp314-315`)
     Harrington (aharrin@luc.edu) beforehand if you cannot attend, or if you have any questions.
 
 
-:doc:`comp317` 
+:doc:`comp317`
     | Section 02W (6284) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday 04:15PM-05:30
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp322` 
+:doc:`comp322`
     | Section 001 (6285) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -448,7 +448,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 422-001.
 
 
-:doc:`comp325` 
+:doc:`comp325`
     | Section 001 (6287) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -457,7 +457,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 425-001
 
 
-:doc:`comp330` 
+:doc:`comp330`
     | Section 001 (4877) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:104 (Lake Shore) Friday 09:20AM-10:10
@@ -466,7 +466,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     This is a hybrid class.  More details will be forthcoming.
 
 
-:doc:`comp363` 
+:doc:`comp363`
     | Section 001 (3061) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -476,7 +476,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     graduate advisor.
 
 
-:doc:`comp366` 
+:doc:`comp366`
     | Section 001 (6295) Credits: 3; In person; Laboratory
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -485,7 +485,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 450-001.
 
 
-:doc:`comp371` 
+:doc:`comp371`
     | Section 001 (6323) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -494,7 +494,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 471-001.
 
 
-:doc:`comp379` 
+:doc:`comp379`
     | Section 001 (6325) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -503,17 +503,17 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 479-001.
 
 
-:doc:`comp381` 
+:doc:`comp381`
     | Section 001 (3742) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:** Combined Section ID:
-    
+
     COMP 381-001 is combined with BIOL 388-001.  Register for BIOL 388-001 (1934).  Also, combined with COMP 488-381 and BIOL 488-001.
 
 
-:doc:`comp386` 
+:doc:`comp386`
     | Section 001 (6326) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -522,7 +522,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 488-386.
 
 
-:doc:`comp391` 
+:doc:`comp391`
     | Section 01E (2085) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -532,18 +532,18 @@ COMP 315  (Description: :doc:`comp314-315`)
     staff member will enroll you.
 
 
-:doc:`comp392` 
+:doc:`comp392`
     | Section 01E (4887) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:** Combined Section ID:
-    
+
     This class satisfies the Engaged Learning requirement in the Undergraduate Research category.
     Instructor Consent Required.
-    
-    
-    
+
+
+
     Combined with COMP 488-392 and BIOL 392-001.
 
 
@@ -555,7 +555,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 001 (4883) Credits: 1; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:15PM-05:30
@@ -563,7 +563,7 @@ COMP 315  (Description: :doc:`comp314-315`)
 
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 500 (6328) Credits: 1; In person; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:117 (Lake Shore) Friday 02:45PM-04:00
@@ -579,7 +579,7 @@ Graduate Courses
 
 
 
-:doc:`comp409` 
+:doc:`comp409`
     | Section 001 (6732) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -587,7 +587,7 @@ Graduate Courses
 
 
 
-:doc:`comp410` 
+:doc:`comp410`
     | Section 001 (6330) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -596,7 +596,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`comp413` 
+:doc:`comp413`
     | Section 001 (3465) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -604,7 +604,7 @@ Graduate Courses
 
 
 
-:doc:`comp417` 
+:doc:`comp417`
     | Section 001 (3052) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Cuneo Hall:003 (Lake Shore) Wednesday 04:15PM-06:45
@@ -612,7 +612,7 @@ Graduate Courses
 
 
 
-:doc:`comp422` 
+:doc:`comp422`
     | Section 001 (6331) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -621,7 +621,7 @@ Graduate Courses
     Combined with COMP 322-001.
 
 
-:doc:`comp425` 
+:doc:`comp425`
     | Section 001 (6339) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -630,7 +630,7 @@ Graduate Courses
     Combined with COMP 325-001
 
 
-:doc:`comp450` 
+:doc:`comp450`
     | Section 001 (6360) Credits: 3; In person; Lecture
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -639,20 +639,20 @@ Graduate Courses
     Combined with COMP 366-001.
 
 
-:doc:`comp453` 
+:doc:`comp453`
     | Section 001 (3064) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:203 (Lake Shore) Thursday 04:15PM-06:45
 
     **Notes:**
     This section of COMP 453 will cover advanced concepts in database access and programming, including SQL, using MySQL and PHP for the project.
-    
-    
+
+
     Outcome: Students will learn application development using the latest software tools.  Students will also learn techniques for web based data retrieval and
     manipulation.
 
 
-:doc:`comp471` 
+:doc:`comp471`
     | Section 001 (6366) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -661,7 +661,7 @@ Graduate Courses
     Combined with COMP 371-001.
 
 
-:doc:`comp479` 
+:doc:`comp479`
     | Section 001 (6363) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -671,7 +671,7 @@ Graduate Courses
 
 
 
-COMP 488 Topic: Bioinformatics 
+COMP 488 Topic: Bioinformatics
     | Section 381 (4215) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -679,23 +679,23 @@ COMP 488 Topic: Bioinformatics
 
     **Notes:**
     Bioinformatics
-    
-    
-    
+
+
+
     Prerequisite: BIOL 101: General Biology I (or equivalent)
-    
-    
-    
+
+
+
     Students will engage in the applications of computer-based tools and database searching to better understand DNA and protein structure, function, and
     evolution. Students will be able to apply their understanding of genetic and evolutionary processes to the appropriate use of computer software and
     manipulation of large databases to accurately predict structural, informational, functional, and evolutionary characteristics of DNA and protein sequences.
-    
-    
+
+
     Combined with COMP 381-001, BIOL 388-001, and BIOL 488-001
 
 
 
-COMP 488 Topic: Computational Neurosci 
+COMP 488 Topic: Computational Neurosci
     | Section 386 (6365) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -703,24 +703,24 @@ COMP 488 Topic: Computational Neurosci
 
     **Notes:**
     Computational Neuroscience
-    
-    
-    
+
+
+
     Prerequisite: COMP 150 OR 170
-    
-    
-    
+
+
+
     Introduces computational methods to understand neural processing in the brain. Levels of representation from low-level, temporally precise neural circuits
     to systems-level rate-encoded models, to information-theoretic approaches. Emphasis on sensory systems, primarily vision and audition, most readily
     demonstrating the need for such computational techniques.
-    
-    
-    
+
+
+
     Combined with COMP 386-001.
 
 
 
-COMP 488 Topic: Metagenomics 
+COMP 488 Topic: Metagenomics
     | Section 392 (4888) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
@@ -728,17 +728,17 @@ COMP 488 Topic: Metagenomics
 
     **Notes:**
     Metagenomics
-    
-    
-    
+
+
+
     Prerequisite: Instructor Consent
-    
-    
-    
+
+
+
     Exploration of next-generation sequencing technologies for assessing microbial diversity in ecological niches. Students will gain hands-on experience with
     metagenomic methodologies while working in an interdisciplinary, collaborative setting.
-    
-    
+
+
     Combined with COMP 392-01E and BIOL 392-001
 
 
@@ -750,7 +750,7 @@ COMP 488 Topic: Metagenomics
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp499` 
+:doc:`comp499`
     | Section 001 (2094) Credits: 1 - 6; In person; Independent Study
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA
@@ -759,7 +759,7 @@ COMP 488 Topic: Metagenomics
     This course involves an internship experience.  Department Consent required, and then a Computer Science Department staff member will enroll you.
 
 
-:doc:`comp605` 
+:doc:`comp605`
     | Section 001 (2902) Credits: 0; In person; FTC-Supervision
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/lakeshorefall.rst
+++ b/deprecated/lakeshorefall.rst
@@ -15,14 +15,14 @@ TextBook information to be updated soon.
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Lake Shore`. 
+:ref:`fall_graduate_courses_list_Lake Shore`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`waterTowerFall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp111` 
+:doc:`comp111`
     | Section 001 (6721) Credits: 3; In person; Lecture
     | Instructor: David B Dennis
     | Crown Center:141 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -51,7 +51,7 @@ Undergraduate Courses
     term papers are required.
 
 
-:doc:`comp122` 
+:doc:`comp122`
     | Section 001 (6147) Credits: 3; In person; Lecture
     | Instructor: David Wetzel
     | Place TBA (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -59,7 +59,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 001 (3043) Credits: 3; In person; Laboratory
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Thursday 06:30PM-09:00
@@ -69,7 +69,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp125` 
+:doc:`comp125`
     | Section 002 (5341) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Sullivan Center:253 (Lake Shore) Tuesday 06:00PM-08:30
@@ -79,7 +79,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 001 (3044) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
@@ -89,7 +89,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 002 (3045) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
@@ -99,7 +99,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 003 (3046) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -109,7 +109,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp150` 
+:doc:`comp150`
     | Section 004 (6148) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -119,7 +119,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 003 (4867) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -127,14 +127,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 004 (6749) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Mundelein Center:0519 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -142,7 +142,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp163` 
+:doc:`comp163`
     | Section 005 (6750) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 04:15PM-05:30
@@ -150,7 +150,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 001/01L (3048) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
@@ -159,18 +159,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-001 (Lecture) will be automatically enrolled in COMP 170-01L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 002/02L (3049) Credits: 3; In person; Lecture/Lab
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -179,18 +179,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-002 (Lecture) will be automatically enrolled in COMP 170-02L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 003/03L (6367) Credits: 3; In person; Lecture/Lab
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -199,18 +199,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp170` 
+:doc:`comp170`
     | Section 004/04L (3556) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -219,13 +219,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP
     170 should contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -239,22 +239,22 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science I.  Eight Week-First Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent is required, and then a Computer Science Department staff member will
     enroll you.
-    
-    
-    
+
+
+
     COMP 170-400 meets on Mondays, 4:15 pm - 8:15 pm, for the first eight weeks of the Semester, replacing holiday/vacation Mondays with Fridays.  So the
     Monday/Friday class schedule is: Mon, Aug 27; Fri, Sept 7; Mon, Sept 10; Mon, Sept 17; Mon, Sept 24; Mon, Oct 1; Fri, Oct 12; and Mon, Oct 15.
-    
-    
+
+
     Labs meet on consecutive Thursdays, 4:15 pm - 6:30 pm: Thurs, Aug 30 through Thurs, Oct 18.
 
 
-:doc:`comp180` 
+:doc:`comp180`
     | Section 001 (6282) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -262,7 +262,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp215` 
+:doc:`comp215`
     | Section 001 (3071) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Crown Center:105 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -271,51 +271,51 @@ Undergraduate Courses
     COMP 215 is crosslisted with MATH 215. Register for MATH 215.
 
 
-:doc:`comp250` 
+:doc:`comp250`
     | Section 01W (3197) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Life Science Buildin:212 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     *This is a writing intensive course.*
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp251` 
+:doc:`comp251`
     | Section 001 (3141) Credits: 3; In person; Lecture
     | Instructor: Guy Bevente
     | Cuneo Hall:117 (Lake Shore) Monday 07:00PM-09:30
 
     **Notes:**
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp264` 
+:doc:`comp264`
     | Section 001 (3373) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.
-    
-    
-    
+
+
+
     Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 001 (6371) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:05
@@ -325,7 +325,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 002/02L (3374) Credits: 3; In person; Lecture/Lab
     | Instructor: Konstantin Laufer
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -334,13 +334,13 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-002 (Lecture) will be automatically enrolled in COMP 271-02L (Lab).
 
 
-:doc:`comp271` 
+:doc:`comp271`
     | Section 003/03L (6372) Credits: 3; In person; Lecture/Lab
     | Instructor: Mark Albert
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday, Friday 01:40PM-02:30
@@ -349,9 +349,9 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
-    
-    
-    
+
+
+
     Students enrolled in COMP 271-003 (Lecture) will be automatically enrolled in COMP 271-03L (Lab).
 
 
@@ -363,14 +363,14 @@ Undergraduate Courses
 
     **Notes:**
     Foundations of Computer Science II.  Eight Week-Second Session.
-    
-    
-    
+
+
+
     This section is restricted to students with undergraduate degrees.  Department Consent required, and then a Computer Science Department staff member will
     enroll you.
 
 
-:doc:`comp309` 
+:doc:`comp309`
     | Section 001 (6733) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -378,7 +378,7 @@ Undergraduate Courses
 
 
 
-:doc:`comp310` 
+:doc:`comp310`
     | Section 001 (6322) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -387,7 +387,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 001 (3464) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:203 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -397,7 +397,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`comp313` 
+:doc:`comp313`
     | Section 002 (6760) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -425,21 +425,21 @@ COMP 315  (Description: :doc:`comp314-315`)
     Harrington (aharrin@luc.edu) beforehand if you cannot attend, or if you have any questions.
 
 
-:doc:`comp317` 
+:doc:`comp317`
     | Section 02W (6284) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:203 (Lake Shore) Monday, Wednesday 04:15PM-05:30
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`comp322` 
+:doc:`comp322`
     | Section 001 (6285) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -448,7 +448,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 422-001.
 
 
-:doc:`comp325` 
+:doc:`comp325`
     | Section 001 (6287) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -457,7 +457,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 425-001
 
 
-:doc:`comp330` 
+:doc:`comp330`
     | Section 001 (4877) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:104 (Lake Shore) Friday 09:20AM-10:10
@@ -466,7 +466,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     This is a hybrid class.  More details will be forthcoming.
 
 
-:doc:`comp363` 
+:doc:`comp363`
     | Section 001 (3061) Credits: 3; In person; Lecture
     | Instructor: Duru Turkoglu
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -476,7 +476,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     graduate advisor.
 
 
-:doc:`comp366` 
+:doc:`comp366`
     | Section 001 (6295) Credits: 3; In person; Laboratory
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -485,7 +485,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 450-001.
 
 
-:doc:`comp371` 
+:doc:`comp371`
     | Section 001 (6323) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -494,7 +494,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 471-001.
 
 
-:doc:`comp379` 
+:doc:`comp379`
     | Section 001 (6325) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -503,17 +503,17 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 479-001.
 
 
-:doc:`comp381` 
+:doc:`comp381`
     | Section 001 (3742) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:** Combined Section ID:
-    
+
     COMP 381-001 is combined with BIOL 388-001.  Register for BIOL 388-001 (1934).  Also, combined with COMP 488-381 and BIOL 488-001.
 
 
-:doc:`comp386` 
+:doc:`comp386`
     | Section 001 (6326) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -522,7 +522,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     Combined with COMP 488-386.
 
 
-:doc:`comp391` 
+:doc:`comp391`
     | Section 01E (2085) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -532,18 +532,18 @@ COMP 315  (Description: :doc:`comp314-315`)
     staff member will enroll you.
 
 
-:doc:`comp392` 
+:doc:`comp392`
     | Section 01E (4887) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:** Combined Section ID:
-    
+
     This class satisfies the Engaged Learning requirement in the Undergraduate Research category.
     Instructor Consent Required.
-    
-    
-    
+
+
+
     Combined with COMP 488-392 and BIOL 392-001.
 
 
@@ -555,7 +555,7 @@ COMP 315  (Description: :doc:`comp314-315`)
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 001 (4883) Credits: 1; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:15PM-05:30
@@ -563,7 +563,7 @@ COMP 315  (Description: :doc:`comp314-315`)
 
 
 
-:doc:`comp399` 
+:doc:`comp399`
     | Section 500 (6328) Credits: 1; In person; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:117 (Lake Shore) Friday 02:45PM-04:00
@@ -579,7 +579,7 @@ Graduate Courses
 
 
 
-:doc:`comp409` 
+:doc:`comp409`
     | Section 001 (6732) Credits: 3; In person; Lecture
     | Instructor: Stephen Doty
     | Dumbach Hall:125 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -587,7 +587,7 @@ Graduate Courses
 
 
 
-:doc:`comp410` 
+:doc:`comp410`
     | Section 001 (6330) Credits: 3; In person; Lecture
     | Instructor: Staff
     | Cuneo Hall:311 (Lake Shore) Thursday 07:00PM-09:30
@@ -596,7 +596,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`comp413` 
+:doc:`comp413`
     | Section 001 (3465) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:202 (Lake Shore) Tuesday 04:15PM-06:45
@@ -604,7 +604,7 @@ Graduate Courses
 
 
 
-:doc:`comp417` 
+:doc:`comp417`
     | Section 001 (3052) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Cuneo Hall:003 (Lake Shore) Wednesday 04:15PM-06:45
@@ -612,7 +612,7 @@ Graduate Courses
 
 
 
-:doc:`comp422` 
+:doc:`comp422`
     | Section 001 (6331) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
@@ -621,7 +621,7 @@ Graduate Courses
     Combined with COMP 322-001.
 
 
-:doc:`comp425` 
+:doc:`comp425`
     | Section 001 (6339) Credits: 3; In person; Lecture
     | Instructor: Karim Kabani
     | Sullivan Center:253 (Lake Shore) Saturday 10:00AM-12:30
@@ -630,7 +630,7 @@ Graduate Courses
     Combined with COMP 325-001
 
 
-:doc:`comp450` 
+:doc:`comp450`
     | Section 001 (6360) Credits: 3; In person; Lecture
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -639,20 +639,20 @@ Graduate Courses
     Combined with COMP 366-001.
 
 
-:doc:`comp453` 
+:doc:`comp453`
     | Section 001 (3064) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:203 (Lake Shore) Thursday 04:15PM-06:45
 
     **Notes:**
     This section of COMP 453 will cover advanced concepts in database access and programming, including SQL, using MySQL and PHP for the project.
-    
-    
+
+
     Outcome: Students will learn application development using the latest software tools.  Students will also learn techniques for web based data retrieval and
     manipulation.
 
 
-:doc:`comp471` 
+:doc:`comp471`
     | Section 001 (6366) Credits: 3; In person; Lecture
     | Instructor: Konstantin Laufer
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -661,7 +661,7 @@ Graduate Courses
     Combined with COMP 371-001.
 
 
-:doc:`comp479` 
+:doc:`comp479`
     | Section 001 (6363) Credits: 3; In person; Lecture
     | Instructor: Dmitriy Dligach
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -671,7 +671,7 @@ Graduate Courses
 
 
 
-COMP 488 Topic: Bioinformatics 
+COMP 488 Topic: Bioinformatics
     | Section 381 (4215) Credits: 3; In person; Lecture
     | Instructor: Heather E. Wheeler
     | Crown Center:103 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -679,23 +679,23 @@ COMP 488 Topic: Bioinformatics
 
     **Notes:**
     Bioinformatics
-    
-    
-    
+
+
+
     Prerequisite: BIOL 101: General Biology I (or equivalent)
-    
-    
-    
+
+
+
     Students will engage in the applications of computer-based tools and database searching to better understand DNA and protein structure, function, and
     evolution. Students will be able to apply their understanding of genetic and evolutionary processes to the appropriate use of computer software and
     manipulation of large databases to accurately predict structural, informational, functional, and evolutionary characteristics of DNA and protein sequences.
-    
-    
+
+
     Combined with COMP 381-001, BIOL 388-001, and BIOL 488-001
 
 
 
-COMP 488 Topic: Computational Neurosci 
+COMP 488 Topic: Computational Neurosci
     | Section 386 (6365) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:202 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -703,24 +703,24 @@ COMP 488 Topic: Computational Neurosci
 
     **Notes:**
     Computational Neuroscience
-    
-    
-    
+
+
+
     Prerequisite: COMP 150 OR 170
-    
-    
-    
+
+
+
     Introduces computational methods to understand neural processing in the brain. Levels of representation from low-level, temporally precise neural circuits
     to systems-level rate-encoded models, to information-theoretic approaches. Emphasis on sensory systems, primarily vision and audition, most readily
     demonstrating the need for such computational techniques.
-    
-    
-    
+
+
+
     Combined with COMP 386-001.
 
 
 
-COMP 488 Topic: Metagenomics 
+COMP 488 Topic: Metagenomics
     | Section 392 (4888) Credits: 3; In person; Lecture
     | Instructor: Michael Bradley Burns
     | Crown Center:103 (Lake Shore) Wednesday 04:15PM-06:45
@@ -728,17 +728,17 @@ COMP 488 Topic: Metagenomics
 
     **Notes:**
     Metagenomics
-    
-    
-    
+
+
+
     Prerequisite: Instructor Consent
-    
-    
-    
+
+
+
     Exploration of next-generation sequencing technologies for assessing microbial diversity in ecological niches. Students will gain hands-on experience with
     metagenomic methodologies while working in an interdisciplinary, collaborative setting.
-    
-    
+
+
     Combined with COMP 392-01E and BIOL 392-001
 
 
@@ -750,7 +750,7 @@ COMP 488 Topic: Metagenomics
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`comp499` 
+:doc:`comp499`
     | Section 001 (2094) Credits: 1 - 6; In person; Independent Study
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA
@@ -759,7 +759,7 @@ COMP 488 Topic: Metagenomics
     This course involves an internship experience.  Department Consent required, and then a Computer Science Department staff member will enroll you.
 
 
-:doc:`comp605` 
+:doc:`comp605`
     | Section 001 (2902) Credits: 0; In person; FTC-Supervision
     | Instructor: Staff
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/lakeshorespring.rst
+++ b/deprecated/lakeshorespring.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 See `Textbook Information <https://docs.google.com/spreadsheets/d/14Hc2m97IDiBYxVjJ6Tz9kOz-RxWYl74LrBh8oj-7VR8/edit#gid=0>`_.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`lakeshorespring_graduate_courses_list`.
@@ -39,7 +39,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 001 (2534) Credits: 3; In person; Laboratory
     | Instructor: Nicholas J Hayward
     | Mundelein Center:0520 (Lake Shore) Monday, Wednesday, Friday 12:35PM-01:25
@@ -49,7 +49,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 002 (2624) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Tuesday 06:00PM-08:30
@@ -59,35 +59,35 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 001 (2535) Credits: 3; Blended; Lecture
     | Instructor: Peter L Dordal
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 12:35PM-01:25
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 002 (2538) Credits: 3; Hybrid; Lecture
     | Instructor: John Nikolas O'Sullivan
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
 
     **Notes:**
     This is a hybrid class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 003 (2539) Credits: 3; In person; Lecture
     | Instructor: Michael Lewis
     | Crown Center:105 (Lake Shore) Thursday 07:00PM-09:30
@@ -97,7 +97,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 004 (5959) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
@@ -107,7 +107,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 005 (6639) Credits: 3; In person; Lecture
     | Instructor: Jason E Streeter
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -115,7 +115,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 001 (2983) Credits: 3; In person; Lecture
     | Instructor: Leo Irakliotis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -123,14 +123,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 002 (3501) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Dumbach Hall:004 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -138,14 +138,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 003 (5121) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Dumbach Hall:004 (Lake Shore) Monday, Wednesday 04:15PM-05:30
@@ -153,14 +153,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 001 (2858) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -170,7 +170,7 @@ Undergraduate Courses
     restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 002 (2859) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:25
@@ -178,14 +178,14 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 003/03L (2861) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -194,18 +194,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 004/04L (2978) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -214,18 +214,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 005/05L (5981) Credits: 3; Hybrid; Lecture/Lab
     | Instructor: Andrew N Harrington
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -244,7 +244,7 @@ Undergraduate Courses
     enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`../courses/comp180` 
+:doc:`../courses/comp180`
     | Section 001 (5122) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -252,49 +252,49 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp250` 
+:doc:`../courses/comp250`
     | Section 01W (2533) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Information Commons:111 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp264` 
+:doc:`../courses/comp264`
     | Section 001 (2532) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp264` 
+:doc:`../courses/comp264`
     | Section 002 (5123) Credits: 3; Blended; Lecture
     | Instructor: Peter L Dordal
     | Mundelein Center:0606 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 001 (2531) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 02:30PM-04:25
@@ -304,7 +304,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 002 (2540) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Crown Center:105 (Lake Shore) Monday, Wednesday 01:40PM-03:35
@@ -314,7 +314,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp310` 
+:doc:`../courses/comp310`
     | Section 001 (5963) Credits: 3; In person; Lecture
     | Instructor: Sarah Kaylor
     | Cuneo Hall:311 (Lake Shore) Tuesday 07:00PM-09:30
@@ -323,7 +323,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`../courses/comp313` 
+:doc:`../courses/comp313`
     | Section 001 (3181) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -333,21 +333,21 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 01W (3589) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Cuneo Hall:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp323` 
+:doc:`../courses/comp323`
     | Section 001 (5982) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Friday 02:45PM-05:15
@@ -356,7 +356,7 @@ Undergraduate Courses
     Combined with COMP 488-323.
 
 
-:doc:`../courses/comp324` 
+:doc:`../courses/comp324`
     | Section 001 (6004) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Monday 04:15PM-06:45
@@ -365,7 +365,7 @@ Undergraduate Courses
     Combined with COMP 424-001.
 
 
-:doc:`../courses/comp330` 
+:doc:`../courses/comp330`
     | Section 001 (5983) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday 11:30AM-12:45
@@ -374,7 +374,7 @@ Undergraduate Courses
     COMP 330-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays.
 
 
-:doc:`../courses/comp339` 
+:doc:`../courses/comp339`
     | Section 001 (5984) Credits: 3; Blended; Lecture
     | Instructor: George Thiruvathukal
     | Mundelein Center:0607 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -383,7 +383,7 @@ Undergraduate Courses
     COMP 339-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays and Fridays.  Combined with COMP 439-001.
 
 
-:doc:`../courses/comp353` 
+:doc:`../courses/comp353`
     | Section 001 (3182) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:117 (Lake Shore) Thursday 04:15PM-06:45
@@ -391,7 +391,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp363` 
+:doc:`../courses/comp363`
     | Section 001 (3590) Credits: 3; Blended; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -399,14 +399,14 @@ Undergraduate Courses
     **Notes:**
     COMP 363 will be a blended course: starting in the classroom, with the middle of the semester online in Zoom at the regular class times, and ending the
     semester in the classroom.  Exams are in the classroom.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students. Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp369` 
+:doc:`../courses/comp369`
     | Section 001 (5968) Credits: 3; In person; Lecture
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Monday 07:00PM-09:30
@@ -415,18 +415,18 @@ Undergraduate Courses
     Combined with COMP 488-369.
 
 
-:doc:`../courses/comp376` 
+:doc:`../courses/comp376`
     | Section 001 (5863) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Inst for Environment:111 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
 
     **Notes:**
     COMP 376 is cross-listed with MATH 376.  Please register for MATH 376.
-    
+
     Combined with COMP 476.
 
 
-:doc:`../courses/comp383` 
+:doc:`../courses/comp383`
     | Section 001 (5989) Credits: 4; In person; Lecture
     | Instructor: Catherine Putonti
     | Crown Center:103 (Lake Shore) Tuesday 04:15PM-07:00
@@ -436,7 +436,7 @@ Undergraduate Courses
 
 
 
-COMP 388 Topic : Adv Topics in Cybersecurity 
+COMP 388 Topic : Adv Topics in Cybersecurity
     | Section 001 (5988) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:103 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -444,24 +444,24 @@ COMP 388 Topic : Adv Topics in Cybersecurity
 
     **Notes:**
     Advanced Topics in Cybersecurity
-    
-    
-    
+
+
+
     Combined with COMP 488-001.
-    
-    
-    
+
+
+
     Description:
-    
+
     Security and privacy are critical components of any system. This class will discuss the latest in computer security and privacy. Topics will include
     distributed systems, voting security, anonymity, privacy, cellular attacks, and much more. Basic knowledge of a programming language, scripting language,
     operating systems, computer networks, and computer security needed for you to do well in this course.
-    
-    
+
+
     Prerequisites:
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 01E (2051) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -470,7 +470,7 @@ COMP 388 Topic : Adv Topics in Cybersecurity
     This class satisfies the Engaged Learning requirement in the Internship category.  Department Consent Required.
 
 
-:doc:`../courses/comp397` 
+:doc:`../courses/comp397`
     | Section 001 (3524) Credits: 1; In person; Seminar
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:45PM-06:00
@@ -494,7 +494,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp410` 
+:doc:`../courses/comp410`
     | Section 001 (5974) Credits: 3; In person; Lecture
     | Instructor: Sarah Kaylor
     | Cuneo Hall:311 (Lake Shore) Tuesday 07:00PM-09:30
@@ -503,7 +503,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`../courses/comp413` 
+:doc:`../courses/comp413`
     | Section 001 (3183) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:117 (Lake Shore) Monday 04:15PM-06:45
@@ -511,7 +511,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp417` 
+:doc:`../courses/comp417`
     | Section 001 (3184) Credits: 3; In person; Lecture
     | Instructor: Nicoletta Christina Montaner
     | Cuneo Hall:103 (Lake Shore) Thursday 04:15PM-06:45
@@ -519,7 +519,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp424` 
+:doc:`../courses/comp424`
     | Section 001 (6006) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Monday 04:15PM-06:45
@@ -528,7 +528,7 @@ Graduate Courses
     Combined with COMP 324-001.
 
 
-:doc:`../courses/comp439` 
+:doc:`../courses/comp439`
     | Section 001 (5995) Credits: 3; Blended; Lecture
     | Instructor: George Thiruvathukal
     | Mundelein Center:0607 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -537,7 +537,7 @@ Graduate Courses
     COMP 439-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays and Fridays.  Combined with COMP 339-001.
 
 
-:doc:`../courses/comp460` 
+:doc:`../courses/comp460`
     | Section 001 (3526) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -545,19 +545,19 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp476` 
+:doc:`../courses/comp476`
     | Section 001 (5862) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Inst for Environment:111 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
 
     **Notes:**
     COMP 476 is cross-listed with MATH 476.
-    
+
     Combined with COMP 376.
 
 
 
-COMP 488 Topic : Adv Topics in Cybersecurity 
+COMP 488 Topic : Adv Topics in Cybersecurity
     | Section 001 (5996) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:103 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -565,25 +565,25 @@ COMP 488 Topic : Adv Topics in Cybersecurity
 
     **Notes:**
     Advanced Topics in Cybersecurity
-    
-    
-    
+
+
+
     Combined with COMP 388-001.
-    
-    
-    
+
+
+
     Description:
-    
+
     Security and privacy are critical components of any system. This class will discuss the latest in computer security and privacy. Topics will include
     distributed systems, voting security, anonymity, privacy, cellular attacks, and much more. Basic knowledge of a programming language, scripting language,
     operating systems, computer networks, and computer security needed for you to do well in this course.
-    
-    
+
+
     Prerequisites:
 
 
 
-COMP 488 Topic : Game Design and Development 
+COMP 488 Topic : Game Design and Development
     | Section 323 (6014) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Friday 02:45PM-05:15
@@ -591,26 +591,26 @@ COMP 488 Topic : Game Design and Development
 
     **Notes:**
     Game Design and Development
-    
-    
-    
+
+
+
     Combined with COMP 323-001.
-    
-    
-    
+
+
+
     This course studies design, development, and publication of games and game-based applications. This includes example games and designers, industry
     practices, and team-based project development.
-    
-    
+
+
     Prerequisite: COMP 271
-    
-    
-    
+
+
+
     Outcomes: Students will acquire an awareness of different game design and development methods, technologies, and techniques suitable for the development of
 
 
 
-COMP 488 Topic : Physical Design & Fabrication 
+COMP 488 Topic : Physical Design & Fabrication
     | Section 369 (5969) Credits: 3; In person; Lecture
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Monday 07:00PM-09:30
@@ -618,23 +618,23 @@ COMP 488 Topic : Physical Design & Fabrication
 
     **Notes:**
     Physical Design & Fabrication
-    
-    
-    
+
+
+
     Combined with COMP 369-001.
-    
-    
-    
+
+
+
     This course explores the role of products in the economy and how things are made, including:  product conceptualization and design, physical design vs.
     design of things that are not physical, rapid prototyping, 3D printing, 2D conceptualization and sketching, 3D modeling, and design reviews.
-    
-    
+
+
     Outcomes: Students will be able to visualize ideas via sketching basic shapes, create 3D models using 3D modeling software, use a 3D Printer, and give
     constructive feedback in peer review sessions.
 
 
 
-COMP 488 Topic : Computational Biology 
+COMP 488 Topic : Computational Biology
     | Section 383 (5997) Credits: 4; In person; Lecture
     | Instructor: Catherine Putonti
     | Crown Center:103 (Lake Shore) Tuesday 04:15PM-07:00
@@ -642,17 +642,17 @@ COMP 488 Topic : Computational Biology
 
     **Notes:**
     Computational Biology
-    
-    
-    
+
+
+
     Combined with COMP 383-001.
-    
-    
-    
+
+
+
     Prerequisites: COMP 271 and COMP 381 (Equivalencies: BIOI/BIOL 388)
-    
-    
-    
+
+
+
     This course presents an algorithmic focus to problems in computational biology. It is built on earlier courses on algorithms and bioinformatics.   Problems
     and solutions covered in this course include gene hunting, sequence comparison, multiple alignment, gene prediction, trees and sequences, databases, and
     rapid sequence analysis.
@@ -666,7 +666,7 @@ COMP 488 Topic : Computational Biology
     *supervisor arranges to get you registered*.  Possible supervisors are: Mark Albert, David Eric Chan-Tin, Dmitriy Dligach, Peter L Dordal, Ronald I Greenberg, Andrew N Harrington, Nicholas J Hayward, William Honig, Konstantin Laufer, Channah Naiman, Catherine Putonti, Chandra N Sekharan, George Thiruvathukal, Heather E. Wheeler, Robert Yacobellis
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 001 (2066) Credits: 1 - 6; In person; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA
@@ -675,7 +675,7 @@ COMP 488 Topic : Computational Biology
     This course involves an internship experience.  Department Consent Required.
 
 
-:doc:`../courses/comp605` 
+:doc:`../courses/comp605`
     | Section 001 (2449) Credits: 0; In person; FTC-Supervision
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/lakeshoresummer.rst
+++ b/deprecated/lakeshoresummer.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 Textbook information will be linked in later.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`lakeshoresummer_graduate_courses_list`.

--- a/deprecated/onlineFall.rst
+++ b/deprecated/onlineFall.rst
@@ -15,14 +15,14 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Online`. 
+:ref:`fall_graduate_courses_list_Online`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`lakeShorefall`
 
-:doc:`waterTowerFall` 
+:doc:`waterTowerFall`
 
 
 
@@ -87,7 +87,7 @@ Undergraduate Courses
     COMP 271-700N is an online section. Required synchronous sessions will be held Thursdays 6-9PM CST and one session Friday 11/30 for holiday make-up class.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 001 (3051) Credits: 3; Online; Lecture
     | Instructor: Matthew Paul Butcher
     | Online Times: TBA
@@ -95,25 +95,25 @@ Undergraduate Courses
     **Notes:**
     This is an online, asynchronous class.  All lectures will be pre-recorded.  Students are asked to attend smaller-group online interactive discussions at
     regular intervals during the semester, with possible times chosen to fit different groups' schedules.
-    
-    
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp340` 
+:doc:`../courses/comp340`
     | Section 001 (6350) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 488-340.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 002 (6291) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -121,12 +121,12 @@ Undergraduate Courses
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 443-002.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 002 (6293) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -134,43 +134,43 @@ Undergraduate Courses
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 447-002.
 
 
-:doc:`../courses/comp364` 
+:doc:`../courses/comp364`
     | Section 001 (6294) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 464-001.
 
 
-:doc:`../courses/comp390` 
+:doc:`../courses/comp390`
     | Section 01E (3466) Credits: 1 - 3; Online; Lecture
     | Instructor: Ronald I Greenberg
     | Online Times: TBA
 
     **Notes:**
     Broadening Participation in STEM (Computing, Mathematics, and Science).
-    
-    
+
+
     This class is online and fully asynchronous, but students must complete service learning activities in-person at a site of their choosing to be approved by
     the instructor in accord with the course design.  To complete the full course (incorporating at least 25 hours of service and other requirements) in one
     semester, register for 3 credits; to spread over two semesters, register for 1 or 2 credits in the first semester (requiring 6 or 14 service hours in the
     first semester, respectively).
-    
-    
+
+
     This class satisfies the Engaged Learning requirement in the Service Learning category.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 02E (4918) Credits: 1 - 6; Online; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Online Times: TBA
@@ -196,7 +196,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 002 (6349) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -204,12 +204,12 @@ Graduate Courses
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 343-002.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 002 (6359) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -217,26 +217,26 @@ Graduate Courses
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 347-002.
 
 
-:doc:`../courses/comp464` 
+:doc:`../courses/comp464`
     | Section 001 (6361) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 364-001.
 
 
 
-COMP 488 Topic: Comp Forensics Investigations 
+COMP 488 Topic: Comp Forensics Investigations
     | Section 340 (6351) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
@@ -244,18 +244,18 @@ COMP 488 Topic: Comp Forensics Investigations
 
     **Notes:**
     Computer Forensics.
-    
-    
-    
+
+
+
     Prerequisites: COMP 170 (or equivalent) and ( COMP 417 or COMP 443 )
-    
-    
-    
-    
-    
+
+
+
+
+
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 340-001.
 
 
@@ -267,7 +267,7 @@ COMP 488 Topic: Comp Forensics Investigations
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 002 (4919) Credits: 1 - 6; Online; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Online Times: TBA

--- a/deprecated/onlinefall.rst
+++ b/deprecated/onlinefall.rst
@@ -15,14 +15,14 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Online`. 
+:ref:`fall_graduate_courses_list_Online`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`lakeShorefall`
 
-:doc:`waterTowerFall` 
+:doc:`waterTowerFall`
 
 
 
@@ -87,7 +87,7 @@ Undergraduate Courses
     COMP 271-700N is an online section. Required synchronous sessions will be held Thursdays 6-9PM CST and one session Friday 11/30 for holiday make-up class.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 001 (3051) Credits: 3; Online; Lecture
     | Instructor: Matthew Paul Butcher
     | Online Times: TBA
@@ -95,25 +95,25 @@ Undergraduate Courses
     **Notes:**
     This is an online, asynchronous class.  All lectures will be pre-recorded.  Students are asked to attend smaller-group online interactive discussions at
     regular intervals during the semester, with possible times chosen to fit different groups' schedules.
-    
-    
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp340` 
+:doc:`../courses/comp340`
     | Section 001 (6350) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 488-340.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 002 (6291) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -121,12 +121,12 @@ Undergraduate Courses
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 443-002.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 002 (6293) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -134,43 +134,43 @@ Undergraduate Courses
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 447-002.
 
 
-:doc:`../courses/comp364` 
+:doc:`../courses/comp364`
     | Section 001 (6294) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 464-001.
 
 
-:doc:`../courses/comp390` 
+:doc:`../courses/comp390`
     | Section 01E (3466) Credits: 1 - 3; Online; Lecture
     | Instructor: Ronald I Greenberg
     | Online Times: TBA
 
     **Notes:**
     Broadening Participation in STEM (Computing, Mathematics, and Science).
-    
-    
+
+
     This class is online and fully asynchronous, but students must complete service learning activities in-person at a site of their choosing to be approved by
     the instructor in accord with the course design.  To complete the full course (incorporating at least 25 hours of service and other requirements) in one
     semester, register for 3 credits; to spread over two semesters, register for 1 or 2 credits in the first semester (requiring 6 or 14 service hours in the
     first semester, respectively).
-    
-    
+
+
     This class satisfies the Engaged Learning requirement in the Service Learning category.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 02E (4918) Credits: 1 - 6; Online; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Online Times: TBA
@@ -196,7 +196,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 002 (6349) Credits: 3; Online; Lecture
     | Instructor: Peter L Dordal
     | Online Times: TBA
@@ -204,12 +204,12 @@ Graduate Courses
     **Notes:**
     This is an online class that includes synchronous and asynchronous interaction among students and Instructor.  Synchronous discussion sessions will be held
     Mondays and Tuesdays at 2:30 pm, and may vary in length from 30 minutes to one hour.  Participation in synchronous sessions is strongly recommended.
-    
-    
+
+
     Combined with COMP 343-002.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 002 (6359) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -217,26 +217,26 @@ Graduate Courses
     **Notes:**
     This is an online class.  The classroom session will be broadcast live on Friday evenings via AdobeConnect, allowing online student interaction.  Sessions
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.
-    
-    
-    
+
+
+
     Combined with COMP 347-002.
 
 
-:doc:`../courses/comp464` 
+:doc:`../courses/comp464`
     | Section 001 (6361) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
 
     **Notes:**
     This is an online, synchronous class.  Synchronous meeting time: Wednesday, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 364-001.
 
 
 
-COMP 488 Topic: Comp Forensics Investigations 
+COMP 488 Topic: Comp Forensics Investigations
     | Section 340 (6351) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Wednesday 07:00PM-09:30
@@ -244,18 +244,18 @@ COMP 488 Topic: Comp Forensics Investigations
 
     **Notes:**
     Computer Forensics.
-    
-    
-    
+
+
+
     Prerequisites: COMP 170 (or equivalent) and ( COMP 417 or COMP 443 )
-    
-    
-    
-    
-    
+
+
+
+
+
     This is an online, synchronous class.  Synchronous meeting time:  Wednesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 340-001.
 
 
@@ -267,7 +267,7 @@ COMP 488 Topic: Comp Forensics Investigations
     *supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 002 (4919) Credits: 1 - 6; Online; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Online Times: TBA

--- a/deprecated/onlinespring.rst
+++ b/deprecated/onlinespring.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 See `Textbook Information <https://docs.google.com/spreadsheets/d/14Hc2m97IDiBYxVjJ6Tz9kOz-RxWYl74LrBh8oj-7VR8/edit#gid=0>`_.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`onlinespring_graduate_courses_list`.
@@ -39,7 +39,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 003 (6110) Credits: 3; Online; Laboratory
     | Instructor: David Wetzel
     | Online Times: TBA
@@ -82,19 +82,19 @@ Undergraduate Courses
     http://www.luc.edu/adult-education/admission/nonscps-enrollment/
 
 
-:doc:`../courses/comp306` 
+:doc:`../courses/comp306`
     | Section 002 (6002) Credits: 3; Online; Lecture
     | Instructor: Channah Naiman
     | Online Times: TBA
 
     **Notes:**
     This class is a totally online, asynchronous course.  Exams may be synchronous and in person.
-    
-    
+
+
     Combined with COMP 400-002.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 001 (4086) Credits: 3; Online; Lecture
     | Instructor: Nicoletta Christina Montaner
     | Online Times: TBA
@@ -113,7 +113,7 @@ Undergraduate Courses
     http://www.luc.edu/adult-education/admission/nonscps-enrollment/
 
 
-:doc:`../courses/comp340` 
+:doc:`../courses/comp340`
     | Section 001 (5966) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Tuesday 07:00PM-09:30
@@ -122,7 +122,7 @@ Undergraduate Courses
     This is an online, synchronous class.  Synchronous meeting time:  Tuesdays, 7:00 pm - 9:30 pm.  Combined with COMP 488-340.
 
 
-:doc:`../courses/comp348` 
+:doc:`../courses/comp348`
     | Section 002 (5978) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -132,25 +132,25 @@ Undergraduate Courses
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.  Combined with COMP 448-002.
 
 
-:doc:`../courses/comp390` 
+:doc:`../courses/comp390`
     | Section 01E (5990) Credits: 1 - 3; Online; Lecture
     | Instructor: Ronald I Greenberg
     | Online Times: TBA
 
     **Notes:**
     Broadening Participation in STEM (Computing, Mathematics, and Science).
-    
-    
+
+
     This class is online and fully asynchronous, but students must complete service learning activities in-person at a site of their choosing to be approved by
     the instructor in accord with the course design.  To complete the full course (incorporating at least 25 hours of service and other requirements) in one
     semester, register for 3 credits; to spread over two semesters, register for 1 or 2 credits in the first semester (requiring 6 or 14 service hours in the
     first semester, respectively).
-    
-    
+
+
     This class satisfies the Engaged Learning requirement in the Service Learning category.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 02E (4287) Credits: 1 - 6; Online; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Online Times: TBA
@@ -175,19 +175,19 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp400` 
+:doc:`../courses/comp400`
     | Section 002 (5993) Credits: 3; Online; Lecture
     | Instructor: Channah Naiman
     | Online Times: TBA
 
     **Notes:**
     This class is a totally online, asynchronous course.  Exams may be synchronous and in person.
-    
-    
+
+
     Combined with COMP 300-002.
 
 
-:doc:`../courses/comp448` 
+:doc:`../courses/comp448`
     | Section 002 (5980) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -197,7 +197,7 @@ Graduate Courses
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.  Combined with COMP 348-002.
 
 
-:doc:`../courses/comp474` 
+:doc:`../courses/comp474`
     | Section 001 (3185) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
@@ -207,7 +207,7 @@ Graduate Courses
 
 
 
-COMP 488 Topic : Comp Forensics Investigations 
+COMP 488 Topic : Comp Forensics Investigations
     | Section 340 (5967) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Tuesday 07:00PM-09:30
@@ -215,20 +215,20 @@ COMP 488 Topic : Comp Forensics Investigations
 
     **Notes:**
     Computer Forensics
-    
-    
-    
+
+
+
     This is an online, synchronous class.  Synchronous meeting time:  Tuesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 340-001.
-    
-    
-    
+
+
+
     Prerequisite: (COMP 150 or COMP 170 or COMP/MATH 215) and (COMP 264 or COMP 317 or COMP 343)
-    
-    
-    
+
+
+
     The course introduces the fundamentals of computer/network/internet forensics, analysis and investigations.
 
 
@@ -240,7 +240,7 @@ COMP 488 Topic : Comp Forensics Investigations
     *supervisor arranges to get you registered*.  Possible supervisors are: Mark Albert, David Eric Chan-Tin, Dmitriy Dligach, Peter L Dordal, Ronald I Greenberg, Andrew N Harrington, Nicholas J Hayward, William Honig, Konstantin Laufer, Channah Naiman, Catherine Putonti, Chandra N Sekharan, George Thiruvathukal, Heather E. Wheeler, Robert Yacobellis
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 002 (5157) Credits: 1 - 6; Online; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Online Times: TBA

--- a/deprecated/onlinesummer.rst
+++ b/deprecated/onlinesummer.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 Textbook information will be linked in later.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`onlinesummer_graduate_courses_list`.
@@ -46,9 +46,9 @@ Undergraduate Courses
 
     **Notes:**
     ***This is a writing intensive class.***  This is an online class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -60,17 +60,17 @@ Undergraduate Courses
 
     **Notes:**
     This is an online class.  The instructor will provide more scheduling details shortly before the beginning of the session.
-    
-    
-    
+
+
+
     This course, intended primarily for non-majors, provides an introduction to computer programming using P5.js (https://p5js.org/), a toolkit for animation,
     multimedia, and more. P5.js is based on Processing, a flexible software sketchbook and a language for learning how to code within the context of the visual"
     arts(http://processing.org).  It is intended for beginning programmers, artists, designers, and researchers. P5.js runs entirely in a web browser and
     requires no special software to download. Students will be able to create code sketches and interactive animations using virtually any web-accessible
     device. No previous coding or programming experience is necessary.
-    
-    
-    
+
+
+
     Outcome: Understanding of computer mechanisms for representing and analyzing numerical and logical information and the power of programmability; practical
     ability to implement useful computing tools. Online portfolio of interactive web animations.
 
@@ -83,9 +83,9 @@ Undergraduate Courses
     **Notes:**
     This is an online class.  Synchronous (online) meeting times:  Mondays, Tuesdays, Thursdays:  5:30 pm - 6:00 pm.  See
     http://anh.cs.luc.edu/150/summerintro.html
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -97,9 +97,9 @@ Undergraduate Courses
 
     **Notes:**
     This is an online class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 

--- a/deprecated/spring.rst
+++ b/deprecated/spring.rst
@@ -1,5 +1,5 @@
 
-Spring 2019 Schedule 
+Spring 2019 Schedule
 ==========================================================================
 Updated 01/02/2019 17:39:05
 
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 See `Textbook Information <https://docs.google.com/spreadsheets/d/14Hc2m97IDiBYxVjJ6Tz9kOz-RxWYl74LrBh8oj-7VR8/edit#gid=0>`_.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`spring_graduate_courses_list`.
@@ -39,7 +39,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 001 (2534) Credits: 3; In person; Laboratory
     | Instructor: Nicholas J Hayward
     | Mundelein Center:0520 (Lake Shore) Monday, Wednesday, Friday 12:35PM-01:25
@@ -49,7 +49,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 002 (2624) Credits: 3; In person; Laboratory
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Tuesday 06:00PM-08:30
@@ -59,7 +59,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp125` 
+:doc:`../courses/comp125`
     | Section 003 (6110) Credits: 3; Online; Laboratory
     | Instructor: David Wetzel
     | Online Times: TBA
@@ -68,35 +68,35 @@ Undergraduate Courses
     This is an online, completely asynchronous class, with the option of Zoom meetings by appointment.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 001 (2535) Credits: 3; Blended; Lecture
     | Instructor: Peter L Dordal
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 12:35PM-01:25
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 002 (2538) Credits: 3; Hybrid; Lecture
     | Instructor: John Nikolas O'Sullivan
     | Crown Center:103 (Lake Shore) Tuesday 07:00PM-09:30
 
     **Notes:**
     This is a hybrid class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 003 (2539) Credits: 3; In person; Lecture
     | Instructor: Michael Lewis
     | Crown Center:105 (Lake Shore) Thursday 07:00PM-09:30
@@ -106,7 +106,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 004 (5959) Credits: 3; In person; Lecture
     | Instructor: Vincent Nguyen
     | Crown Center:105 (Lake Shore) Monday 07:00PM-09:30
@@ -116,7 +116,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp150` 
+:doc:`../courses/comp150`
     | Section 005 (6639) Credits: 3; In person; Lecture
     | Instructor: Jason E Streeter
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -124,7 +124,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 001 (2983) Credits: 3; In person; Lecture
     | Instructor: Leo Irakliotis
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 08:30AM-09:45
@@ -132,14 +132,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 002 (3501) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Dumbach Hall:004 (Lake Shore) Monday, Wednesday 02:45PM-04:00
@@ -147,14 +147,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp163` 
+:doc:`../courses/comp163`
     | Section 003 (5121) Credits: 3; In person; Lecture
     | Instructor: Nathan Lopez
     | Dumbach Hall:004 (Lake Shore) Monday, Wednesday 04:15PM-05:30
@@ -162,14 +162,14 @@ Undergraduate Courses
     **Notes:**
     This course is primarily intended to serve certain majors and minors.  Students wishing to satisfy Core requirements in the Quantitative Analysis knowledge
     area are encouraged to enroll in COMP 125 or COMP 150 instead.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 001 (2858) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 08:15AM-09:05
@@ -179,7 +179,7 @@ Undergraduate Courses
     restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 002 (2859) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 02:30PM-04:25
@@ -187,14 +187,14 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 003/03L (2861) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -203,18 +203,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-003 (Lecture) will be automatically enrolled in COMP 170-03L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 004/04L (2978) Credits: 3; In person; Lecture/Lab
     | Instructor: William Honig
     | Cuneo Hall:311 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
@@ -223,18 +223,18 @@ Undergraduate Courses
     **Notes:**
     This course is restricted to students in the College of Arts and Sciences.  Students from other schools specifically wishing to enroll in COMP 170 should
     contact the Computer Science Department to request an enrollment override.
-    
-    
-    
+
+
+
     Students enrolled in COMP 170-004 (Lecture) will be automatically enrolled in COMP 170-04L (Lab).
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp170` 
+:doc:`../courses/comp170`
     | Section 005/05L (5981) Credits: 3; Hybrid; Lecture/Lab
     | Instructor: Andrew N Harrington
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -264,7 +264,7 @@ Undergraduate Courses
     COMP 170-700N is an online section. Required synchronous sessions will be held Tuesdays 6-9PM CST
 
 
-:doc:`../courses/comp180` 
+:doc:`../courses/comp180`
     | Section 001 (5122) Credits: 3; In person; Lecture
     | Instructor: Ting Xiao
     | Crown Center:105 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -272,49 +272,49 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp250` 
+:doc:`../courses/comp250`
     | Section 01W (2533) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Information Commons:111 (Lake Shore) Monday, Wednesday 02:45PM-04:00
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp264` 
+:doc:`../courses/comp264`
     | Section 001 (2532) Credits: 3; Blended; Lecture
     | Instructor: Ronald I Greenberg
     | Cuneo Hall:324 (Lake Shore) Tuesday, Thursday 01:00PM-02:15
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp264` 
+:doc:`../courses/comp264`
     | Section 002 (5123) Credits: 3; Blended; Lecture
     | Instructor: Peter L Dordal
     | Mundelein Center:0606 (Lake Shore) Monday, Wednesday, Friday 11:30AM-12:20
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 001 (2531) Credits: 3; In person; Lecture
     | Instructor: Chandra N Sekharan
     | Cuneo Hall:302 (Lake Shore) Tuesday, Thursday 02:30PM-04:25
@@ -324,7 +324,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp271` 
+:doc:`../courses/comp271`
     | Section 002 (2540) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Crown Center:105 (Lake Shore) Monday, Wednesday 01:40PM-03:35
@@ -357,7 +357,7 @@ Undergraduate Courses
     http://www.luc.edu/adult-education/admission/nonscps-enrollment/
 
 
-:doc:`../courses/comp306` 
+:doc:`../courses/comp306`
     | Section 001 (6000) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Corboy Law Center:L08 (Water Tower) Wednesday 04:15PM-06:45
@@ -366,32 +366,32 @@ Undergraduate Courses
     Combined with COMP 400-001.
 
 
-:doc:`../courses/comp306` 
+:doc:`../courses/comp306`
     | Section 002 (6002) Credits: 3; Online; Lecture
     | Instructor: Channah Naiman
     | Online Times: TBA
 
     **Notes:**
     This class is a totally online, asynchronous course.  Exams may be synchronous and in person.
-    
-    
+
+
     Combined with COMP 400-002.
 
 
-:doc:`../courses/comp305` 
+:doc:`../courses/comp305`
     | Section 001 (5961) Credits: 3; Blended; Lecture
     | Instructor: Ammar Ahmed
     | Corboy Law Center:0522 (Water Tower) Tuesday 05:30PM-08:00
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     Combined with COMP 488-305.
 
 
-:doc:`../courses/comp310` 
+:doc:`../courses/comp310`
     | Section 001 (5963) Credits: 3; In person; Lecture
     | Instructor: Sarah Kaylor
     | Cuneo Hall:311 (Lake Shore) Tuesday 07:00PM-09:30
@@ -400,7 +400,7 @@ Undergraduate Courses
     Combined with COMP 410-001.
 
 
-:doc:`../courses/comp313` 
+:doc:`../courses/comp313`
     | Section 001 (3181) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday, Friday 09:20AM-10:10
@@ -410,7 +410,7 @@ Undergraduate Courses
     graduate advisor.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 001 (4086) Credits: 3; Online; Lecture
     | Instructor: Nicoletta Christina Montaner
     | Online Times: TBA
@@ -419,16 +419,16 @@ Undergraduate Courses
     This is an online class, and totally asynchronous, with the option of meeting by appointment online or in person.
 
 
-:doc:`../courses/comp317` 
+:doc:`../courses/comp317`
     | Section 01W (3589) Credits: 3; In person; Lecture
     | Instructor: Roxanne Schwab
     | Cuneo Hall:103 (Lake Shore) Wednesday 04:15PM-06:45
 
     **Notes:**
     **This is a writing intensive class.**
-    
-    
-    
+
+
+
     This class is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -443,7 +443,7 @@ Undergraduate Courses
     http://www.luc.edu/adult-education/admission/nonscps-enrollment/
 
 
-:doc:`../courses/comp323` 
+:doc:`../courses/comp323`
     | Section 001 (5982) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Friday 02:45PM-05:15
@@ -452,7 +452,7 @@ Undergraduate Courses
     Combined with COMP 488-323.
 
 
-:doc:`../courses/comp324` 
+:doc:`../courses/comp324`
     | Section 001 (6004) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Monday 04:15PM-06:45
@@ -461,7 +461,7 @@ Undergraduate Courses
     Combined with COMP 424-001.
 
 
-:doc:`../courses/comp330` 
+:doc:`../courses/comp330`
     | Section 001 (5983) Credits: 3; Hybrid; Lecture
     | Instructor: George Thiruvathukal
     | Cuneo Hall:311 (Lake Shore) Monday, Wednesday 11:30AM-12:45
@@ -470,7 +470,7 @@ Undergraduate Courses
     COMP 330-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays.
 
 
-:doc:`../courses/comp339` 
+:doc:`../courses/comp339`
     | Section 001 (5984) Credits: 3; Blended; Lecture
     | Instructor: George Thiruvathukal
     | Mundelein Center:0607 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -479,7 +479,7 @@ Undergraduate Courses
     COMP 339-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays and Fridays.  Combined with COMP 439-001.
 
 
-:doc:`../courses/comp340` 
+:doc:`../courses/comp340`
     | Section 001 (5966) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Tuesday 07:00PM-09:30
@@ -488,7 +488,7 @@ Undergraduate Courses
     This is an online, synchronous class.  Synchronous meeting time:  Tuesdays, 7:00 pm - 9:30 pm.  Combined with COMP 488-340.
 
 
-:doc:`../courses/comp341` 
+:doc:`../courses/comp341`
     | Section 001 (6005) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Wednesday 07:00PM-09:30
@@ -497,7 +497,7 @@ Undergraduate Courses
     Combined with COMP 441-001.
 
 
-:doc:`../courses/comp348` 
+:doc:`../courses/comp348`
     | Section 001 (5977) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | Corboy Law Center:0105 (Water Tower) Friday 05:45PM-08:15
@@ -506,7 +506,7 @@ Undergraduate Courses
     Combined with COMP 448-001.
 
 
-:doc:`../courses/comp348` 
+:doc:`../courses/comp348`
     | Section 002 (5978) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -516,7 +516,7 @@ Undergraduate Courses
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.  Combined with COMP 448-002.
 
 
-:doc:`../courses/comp353` 
+:doc:`../courses/comp353`
     | Section 001 (3182) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Cuneo Hall:117 (Lake Shore) Thursday 04:15PM-06:45
@@ -524,7 +524,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp363` 
+:doc:`../courses/comp363`
     | Section 001 (3590) Credits: 3; Blended; Lecture
     | Instructor: Andrew N Harrington
     | Cuneo Hall:202 (Lake Shore) Tuesday, Thursday 10:00AM-11:15
@@ -532,14 +532,14 @@ Undergraduate Courses
     **Notes:**
     COMP 363 will be a blended course: starting in the classroom, with the middle of the semester online in Zoom at the regular class times, and ending the
     semester in the classroom.  Exams are in the classroom.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students. Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
 
-:doc:`../courses/comp369` 
+:doc:`../courses/comp369`
     | Section 001 (5968) Credits: 3; In person; Lecture
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Monday 07:00PM-09:30
@@ -548,7 +548,7 @@ Undergraduate Courses
     Combined with COMP 488-369.
 
 
-:doc:`../courses/comp370` 
+:doc:`../courses/comp370`
     | Section 001 (5970) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0602 (Water Tower) Friday 02:45PM-05:15
@@ -557,7 +557,7 @@ Undergraduate Courses
     Combined with COMP 488-370.
 
 
-:doc:`../courses/comp373` 
+:doc:`../courses/comp373`
     | Section 001 (5972) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0305 (Water Tower) Monday 07:00PM-09:30
@@ -566,18 +566,18 @@ Undergraduate Courses
     Combined with COMP 473-001.
 
 
-:doc:`../courses/comp376` 
+:doc:`../courses/comp376`
     | Section 001 (5863) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Inst for Environment:111 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
 
     **Notes:**
     COMP 376 is cross-listed with MATH 376.  Please register for MATH 376.
-    
+
     Combined with COMP 476.
 
 
-:doc:`../courses/comp383` 
+:doc:`../courses/comp383`
     | Section 001 (5989) Credits: 4; In person; Lecture
     | Instructor: Catherine Putonti
     | Crown Center:103 (Lake Shore) Tuesday 04:15PM-07:00
@@ -587,7 +587,7 @@ Undergraduate Courses
 
 
 
-COMP 388 Topic : Adv Topics in Cybersecurity 
+COMP 388 Topic : Adv Topics in Cybersecurity
     | Section 001 (5988) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:103 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -595,42 +595,42 @@ COMP 388 Topic : Adv Topics in Cybersecurity
 
     **Notes:**
     Advanced Topics in Cybersecurity
-    
-    
-    
+
+
+
     Combined with COMP 488-001.
-    
-    
-    
+
+
+
     Description:
-    
+
     Security and privacy are critical components of any system. This class will discuss the latest in computer security and privacy. Topics will include
     distributed systems, voting security, anonymity, privacy, cellular attacks, and much more. Basic knowledge of a programming language, scripting language,
     operating systems, computer networks, and computer security needed for you to do well in this course.
-    
-    
+
+
     Prerequisites:
 
 
-:doc:`../courses/comp390` 
+:doc:`../courses/comp390`
     | Section 01E (5990) Credits: 1 - 3; Online; Lecture
     | Instructor: Ronald I Greenberg
     | Online Times: TBA
 
     **Notes:**
     Broadening Participation in STEM (Computing, Mathematics, and Science).
-    
-    
+
+
     This class is online and fully asynchronous, but students must complete service learning activities in-person at a site of their choosing to be approved by
     the instructor in accord with the course design.  To complete the full course (incorporating at least 25 hours of service and other requirements) in one
     semester, register for 3 credits; to spread over two semesters, register for 1 or 2 credits in the first semester (requiring 6 or 14 service hours in the
     first semester, respectively).
-    
-    
+
+
     This class satisfies the Engaged Learning requirement in the Service Learning category.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 01E (2051) Credits: 1 - 6; In person; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Place TBA (Lake Shore) Times: TBA
@@ -639,7 +639,7 @@ COMP 388 Topic : Adv Topics in Cybersecurity
     This class satisfies the Engaged Learning requirement in the Internship category.  Department Consent Required.
 
 
-:doc:`../courses/comp391` 
+:doc:`../courses/comp391`
     | Section 02E (4287) Credits: 1 - 6; Online; Field Studies
     | Instructor: Ronald I Greenberg, Robert Yacobellis
     | Online Times: TBA
@@ -648,7 +648,7 @@ COMP 388 Topic : Adv Topics in Cybersecurity
     This is an online class.  This class satisfies the Engaged Learning requirement in the Internship category.  Department Consent required.
 
 
-:doc:`../courses/comp397` 
+:doc:`../courses/comp397`
     | Section 001 (3524) Credits: 1; In person; Seminar
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Thursday 04:45PM-06:00
@@ -672,7 +672,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp400` 
+:doc:`../courses/comp400`
     | Section 001 (5992) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Corboy Law Center:L08 (Water Tower) Wednesday 04:15PM-06:45
@@ -681,19 +681,19 @@ Graduate Courses
     Combined with COMP 300-001.
 
 
-:doc:`../courses/comp400` 
+:doc:`../courses/comp400`
     | Section 002 (5993) Credits: 3; Online; Lecture
     | Instructor: Channah Naiman
     | Online Times: TBA
 
     **Notes:**
     This class is a totally online, asynchronous course.  Exams may be synchronous and in person.
-    
-    
+
+
     Combined with COMP 300-002.
 
 
-:doc:`../courses/comp410` 
+:doc:`../courses/comp410`
     | Section 001 (5974) Credits: 3; In person; Lecture
     | Instructor: Sarah Kaylor
     | Cuneo Hall:311 (Lake Shore) Tuesday 07:00PM-09:30
@@ -702,7 +702,7 @@ Graduate Courses
     Combined with COMP 310-001.
 
 
-:doc:`../courses/comp413` 
+:doc:`../courses/comp413`
     | Section 001 (3183) Credits: 3; In person; Lecture
     | Instructor: Robert Yacobellis
     | Cuneo Hall:117 (Lake Shore) Monday 04:15PM-06:45
@@ -710,7 +710,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp417` 
+:doc:`../courses/comp417`
     | Section 001 (3184) Credits: 3; In person; Lecture
     | Instructor: Nicoletta Christina Montaner
     | Cuneo Hall:103 (Lake Shore) Thursday 04:15PM-06:45
@@ -718,7 +718,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp424` 
+:doc:`../courses/comp424`
     | Section 001 (6006) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Monday 04:15PM-06:45
@@ -727,7 +727,7 @@ Graduate Courses
     Combined with COMP 324-001.
 
 
-:doc:`../courses/comp439` 
+:doc:`../courses/comp439`
     | Section 001 (5995) Credits: 3; Blended; Lecture
     | Instructor: George Thiruvathukal
     | Mundelein Center:0607 (Lake Shore) Monday, Wednesday, Friday 10:25AM-11:15
@@ -736,7 +736,7 @@ Graduate Courses
     COMP 439-001 is a hybrid class.  It meets in person on Mondays and online on Wednesdays and Fridays.  Combined with COMP 339-001.
 
 
-:doc:`../courses/comp441` 
+:doc:`../courses/comp441`
     | Section 001 (6007) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Wednesday 07:00PM-09:30
@@ -745,7 +745,7 @@ Graduate Courses
     Combined with COMP 341-001.
 
 
-:doc:`../courses/comp448` 
+:doc:`../courses/comp448`
     | Section 001 (5979) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | Corboy Law Center:0105 (Water Tower) Friday 05:45PM-08:15
@@ -754,7 +754,7 @@ Graduate Courses
     Combined with COMP 348-001.
 
 
-:doc:`../courses/comp448` 
+:doc:`../courses/comp448`
     | Section 002 (5980) Credits: 3; Online; Lecture
     | Instructor: Corby Schmitz
     | Online Times: TBA
@@ -764,7 +764,7 @@ Graduate Courses
     will also be recorded and made available.  Students may participate synchronously or asynchronously at their discretion.  Combined with COMP 348-002.
 
 
-:doc:`../courses/comp460` 
+:doc:`../courses/comp460`
     | Section 001 (3526) Credits: 3; In person; Lecture
     | Instructor: Mark Albert
     | Cuneo Hall:311 (Lake Shore) Wednesday 04:15PM-06:45
@@ -772,7 +772,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp473` 
+:doc:`../courses/comp473`
     | Section 001 (5973) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0305 (Water Tower) Monday 07:00PM-09:30
@@ -781,7 +781,7 @@ Graduate Courses
     Combined with COMP 373-001.
 
 
-:doc:`../courses/comp474` 
+:doc:`../courses/comp474`
     | Section 001 (3185) Credits: 3; Online; Lecture
     | Instructor: Christopher Stone
     | Online Wednesday 07:00PM-09:30
@@ -790,19 +790,19 @@ Graduate Courses
     This is an online class.  Synchronous meeting time:  Wednesday, 7:00 pm - 9:30 pm.
 
 
-:doc:`../courses/comp476` 
+:doc:`../courses/comp476`
     | Section 001 (5862) Credits: 3; In person; Lecture
     | Instructor: Christine A Haught
     | Inst for Environment:111 (Lake Shore) Tuesday, Thursday 02:30PM-03:45
 
     **Notes:**
     COMP 476 is cross-listed with MATH 476.
-    
+
     Combined with COMP 376.
 
 
 
-COMP 488 Topic : Adv Topics in Cybersecurity 
+COMP 488 Topic : Adv Topics in Cybersecurity
     | Section 001 (5996) Credits: 3; In person; Lecture
     | Instructor: David Eric Chan-Tin
     | Cuneo Hall:103 (Lake Shore) Tuesday, Thursday 11:30AM-12:45
@@ -810,25 +810,25 @@ COMP 488 Topic : Adv Topics in Cybersecurity
 
     **Notes:**
     Advanced Topics in Cybersecurity
-    
-    
-    
+
+
+
     Combined with COMP 388-001.
-    
-    
-    
+
+
+
     Description:
-    
+
     Security and privacy are critical components of any system. This class will discuss the latest in computer security and privacy. Topics will include
     distributed systems, voting security, anonymity, privacy, cellular attacks, and much more. Basic knowledge of a programming language, scripting language,
     operating systems, computer networks, and computer security needed for you to do well in this course.
-    
-    
+
+
     Prerequisites:
 
 
 
-COMP 488 Topic : Database Administration 
+COMP 488 Topic : Database Administration
     | Section 305 (5975) Credits: 3; Blended; Lecture
     | Instructor: Ammar Ahmed
     | Corboy Law Center:0522 (Water Tower) Tuesday 05:30PM-08:00
@@ -836,27 +836,27 @@ COMP 488 Topic : Database Administration
 
     **Notes:**
     Database Administration
-    
-    
-    
+
+
+
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     Combined with COMP 305-001.
-    
-    
-    
+
+
+
     Prerequisites:  Comp 251 or Comp 271.
-    
-    
-    
+
+
+
     Business and scientific institutions increasingly use large commercial data base systems.  This course teaches the theory and practice for the definition,
     security, backup, tuning, and recovery of these systems.
 
 
 
-COMP 488 Topic : Game Design and Development 
+COMP 488 Topic : Game Design and Development
     | Section 323 (6014) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Cuneo Hall:311 (Lake Shore) Friday 02:45PM-05:15
@@ -864,26 +864,26 @@ COMP 488 Topic : Game Design and Development
 
     **Notes:**
     Game Design and Development
-    
-    
-    
+
+
+
     Combined with COMP 323-001.
-    
-    
-    
+
+
+
     This course studies design, development, and publication of games and game-based applications. This includes example games and designers, industry
     practices, and team-based project development.
-    
-    
+
+
     Prerequisite: COMP 271
-    
-    
-    
+
+
+
     Outcomes: Students will acquire an awareness of different game design and development methods, technologies, and techniques suitable for the development of
 
 
 
-COMP 488 Topic : Comp Forensics Investigations 
+COMP 488 Topic : Comp Forensics Investigations
     | Section 340 (5967) Credits: 3; Online; Lecture
     | Instructor: Thomas Yarrish
     | Online Tuesday 07:00PM-09:30
@@ -891,25 +891,25 @@ COMP 488 Topic : Comp Forensics Investigations
 
     **Notes:**
     Computer Forensics
-    
-    
-    
+
+
+
     This is an online, synchronous class.  Synchronous meeting time:  Tuesdays, 7:00 pm - 9:30 pm.
-    
-    
+
+
     Combined with COMP 340-001.
-    
-    
-    
+
+
+
     Prerequisite: (COMP 150 or COMP 170 or COMP/MATH 215) and (COMP 264 or COMP 317 or COMP 343)
-    
-    
-    
+
+
+
     The course introduces the fundamentals of computer/network/internet forensics, analysis and investigations.
 
 
 
-COMP 488 Topic : Physical Design & Fabrication 
+COMP 488 Topic : Physical Design & Fabrication
     | Section 369 (5969) Credits: 3; In person; Lecture
     | Instructor: Jonathan Durston
     | Sullivan Center:253 (Lake Shore) Monday 07:00PM-09:30
@@ -917,23 +917,23 @@ COMP 488 Topic : Physical Design & Fabrication
 
     **Notes:**
     Physical Design & Fabrication
-    
-    
-    
+
+
+
     Combined with COMP 369-001.
-    
-    
-    
+
+
+
     This course explores the role of products in the economy and how things are made, including:  product conceptualization and design, physical design vs.
     design of things that are not physical, rapid prototyping, 3D printing, 2D conceptualization and sketching, 3D modeling, and design reviews.
-    
-    
+
+
     Outcomes: Students will be able to visualize ideas via sketching basic shapes, create 3D models using 3D modeling software, use a 3D Printer, and give
     constructive feedback in peer review sessions.
 
 
 
-COMP 488 Topic : Software Quality & Testing 
+COMP 488 Topic : Software Quality & Testing
     | Section 370 (5971) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0602 (Water Tower) Friday 02:45PM-05:15
@@ -941,26 +941,26 @@ COMP 488 Topic : Software Quality & Testing
 
     **Notes:**
     Software Quality & Testing
-    
-    
-    
+
+
+
     Combined with COMP 370-001.
-    
-    
-    
+
+
+
     Prerequisite: Comp 271.
-    
-    
-    
+
+
+
     The course teaches software testing and quality control concepts, principles, and techniques including black box and white box testing, coverage testing,
     test case development, and regression testing.
-    
-    
+
+
     Outcome: Students will learn how to prevent errors, how to get 'bugs' out of software, and be able to apply this knowledge in other courses and projects.
 
 
 
-COMP 488 Topic : Computational Biology 
+COMP 488 Topic : Computational Biology
     | Section 383 (5997) Credits: 4; In person; Lecture
     | Instructor: Catherine Putonti
     | Crown Center:103 (Lake Shore) Tuesday 04:15PM-07:00
@@ -968,24 +968,24 @@ COMP 488 Topic : Computational Biology
 
     **Notes:**
     Computational Biology
-    
-    
-    
+
+
+
     Combined with COMP 383-001.
-    
-    
-    
+
+
+
     Prerequisites: COMP 271 and COMP 381 (Equivalencies: BIOI/BIOL 388)
-    
-    
-    
+
+
+
     This course presents an algorithmic focus to problems in computational biology. It is built on earlier courses on algorithms and bioinformatics.   Problems
     and solutions covered in this course include gene hunting, sequence comparison, multiple alignment, gene prediction, trees and sequences, databases, and
     rapid sequence analysis.
 
 
 
-COMP 488 Topic : Organizational Change & Dev. 
+COMP 488 Topic : Organizational Change & Dev.
     | Section 472 (5965) Credits: 3; In person; Lecture
     | Instructor: Guy Bevente
     | Maguire Hall:330 (Water Tower) Tuesday 07:00PM-09:30
@@ -1003,7 +1003,7 @@ COMP 488 Topic : Organizational Change & Dev.
     *supervisor arranges to get you registered*.  Possible supervisors are: Mark Albert, David Eric Chan-Tin, Dmitriy Dligach, Peter L Dordal, Ronald I Greenberg, Andrew N Harrington, Nicholas J Hayward, William Honig, Konstantin Laufer, Channah Naiman, Catherine Putonti, Chandra N Sekharan, George Thiruvathukal, Heather E. Wheeler, Robert Yacobellis
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 001 (2066) Credits: 1 - 6; In person; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA
@@ -1012,7 +1012,7 @@ COMP 488 Topic : Organizational Change & Dev.
     This course involves an internship experience.  Department Consent Required.
 
 
-:doc:`../courses/comp499` 
+:doc:`../courses/comp499`
     | Section 002 (5157) Credits: 1 - 6; Online; Independent Study
     | Instructor: Andrew N Harrington, Channah Naiman
     | Online Times: TBA
@@ -1021,7 +1021,7 @@ COMP 488 Topic : Organizational Change & Dev.
     This is an online class.  This course involves an internship experience.  Department Consent Required.
 
 
-:doc:`../courses/comp605` 
+:doc:`../courses/comp605`
     | Section 001 (2449) Credits: 0; In person; FTC-Supervision
     | Instructor: Andrew N Harrington, Channah Naiman
     | Place TBA (Lake Shore) Times: TBA

--- a/deprecated/summer.rst
+++ b/deprecated/summer.rst
@@ -1,5 +1,5 @@
 
-Summer 2019 Schedule 
+Summer 2019 Schedule
 ==========================================================================
 Updated 12/18/2018 15:53:02
 
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 Textbook information will be linked in later.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`summer_graduate_courses_list`.
@@ -46,9 +46,9 @@ Undergraduate Courses
 
     **Notes:**
     ***This is a writing intensive class.***  This is an online class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -60,17 +60,17 @@ Undergraduate Courses
 
     **Notes:**
     This is an online class.  The instructor will provide more scheduling details shortly before the beginning of the session.
-    
-    
-    
+
+
+
     This course, intended primarily for non-majors, provides an introduction to computer programming using P5.js (https://p5js.org/), a toolkit for animation,
     multimedia, and more. P5.js is based on Processing, a flexible software sketchbook and a language for learning how to code within the context of the visual"
     arts(http://processing.org).  It is intended for beginning programmers, artists, designers, and researchers. P5.js runs entirely in a web browser and
     requires no special software to download. Students will be able to create code sketches and interactive animations using virtually any web-accessible
     device. No previous coding or programming experience is necessary.
-    
-    
-    
+
+
+
     Outcome: Understanding of computer mechanisms for representing and analyzing numerical and logical information and the power of programmability; practical
     ability to implement useful computing tools. Online portfolio of interactive web animations.
 
@@ -83,9 +83,9 @@ Undergraduate Courses
     **Notes:**
     This is an online class.  Synchronous (online) meeting times:  Mondays, Tuesdays, Thursdays:  5:30 pm - 6:00 pm.  See
     http://anh.cs.luc.edu/150/summerintro.html
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -97,9 +97,9 @@ Undergraduate Courses
 
     **Notes:**
     This is an online class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This course is restricted to undergraduate students.  Graduate students wishing to enroll in a section of this course should contact their departmental
     graduate advisor.
 
@@ -111,13 +111,13 @@ Undergraduate Courses
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     This class satisfies the Engaged Learning requirement in the Undergraduate Research category.
-    
-    
-    
+
+
+
     Combined with COMP 412-001.
 
 
@@ -246,9 +246,9 @@ Graduate Courses
 
     **Notes:**
     This is a blended class.  More details will be forthcoming.
-    
-    
-    
+
+
+
     Combined with COMP 312-01E.
 
 

--- a/deprecated/waterTowerFall.rst
+++ b/deprecated/waterTowerFall.rst
@@ -15,14 +15,14 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Water Tower`. 
+:ref:`fall_graduate_courses_list_Water Tower`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`lakeShorefall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp324` 
+:doc:`../courses/comp324`
     | Section 001 (6286) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -50,7 +50,7 @@ Undergraduate Courses
     Combined with COMP 424-001.
 
 
-:doc:`../courses/comp333` 
+:doc:`../courses/comp333`
     | Section 001 (6288) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -59,7 +59,7 @@ Undergraduate Courses
     Combined with COMP 433-001.
 
 
-:doc:`../courses/comp336` 
+:doc:`../courses/comp336`
     | Section 001 (6289) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -68,7 +68,7 @@ Undergraduate Courses
     Combined with COMP 436-001.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 001 (6290) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -77,7 +77,7 @@ Undergraduate Courses
     Combined with COMP 443-001.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 001 (6292) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -86,7 +86,7 @@ Undergraduate Courses
     Combined with COMP 447-001.
 
 
-:doc:`../courses/comp377` 
+:doc:`../courses/comp377`
     | Section 001 (6324) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45
@@ -111,7 +111,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp403` 
+:doc:`../courses/comp403`
     | Section 001 (6329) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Corboy Law Center:0423 (Water Tower) Wednesday 07:00PM-09:30
@@ -119,7 +119,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp424` 
+:doc:`../courses/comp424`
     | Section 001 (6377) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -128,7 +128,7 @@ Graduate Courses
     Combined with COMP 324-001.
 
 
-:doc:`../courses/comp433` 
+:doc:`../courses/comp433`
     | Section 001 (6340) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -137,7 +137,7 @@ Graduate Courses
     Combined with COMP 333-001.
 
 
-:doc:`../courses/comp436` 
+:doc:`../courses/comp436`
     | Section 001 (6341) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -146,7 +146,7 @@ Graduate Courses
     Combined with COMP 336-001.
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 001 (6342) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -155,7 +155,7 @@ Graduate Courses
     Combined with COMP 343-001.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 001 (6358) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -164,7 +164,7 @@ Graduate Courses
     Combined with COMP 347-001.
 
 
-:doc:`../courses/comp477` 
+:doc:`../courses/comp477`
     | Section 001 (6362) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45

--- a/deprecated/watertowerfall.rst
+++ b/deprecated/watertowerfall.rst
@@ -15,14 +15,14 @@ See `Textbook Information <https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 
 You can skip down to
-:ref:`fall_graduate_courses_list_Water Tower`. 
+:ref:`fall_graduate_courses_list_Water Tower`.
 
 **View Campus Specific Courses below :**
 
@@ -30,7 +30,7 @@ You can skip down to
 
 :doc:`lakeShorefall`
 
-:doc:`onlineFall` 
+:doc:`onlineFall`
 
 
 
@@ -41,7 +41,7 @@ Undergraduate Courses
 
 
 
-:doc:`../courses/comp324` 
+:doc:`../courses/comp324`
     | Section 001 (6286) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -50,7 +50,7 @@ Undergraduate Courses
     Combined with COMP 424-001.
 
 
-:doc:`../courses/comp333` 
+:doc:`../courses/comp333`
     | Section 001 (6288) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -59,7 +59,7 @@ Undergraduate Courses
     Combined with COMP 433-001.
 
 
-:doc:`../courses/comp336` 
+:doc:`../courses/comp336`
     | Section 001 (6289) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -68,7 +68,7 @@ Undergraduate Courses
     Combined with COMP 436-001.
 
 
-:doc:`../courses/comp343` 
+:doc:`../courses/comp343`
     | Section 001 (6290) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -77,7 +77,7 @@ Undergraduate Courses
     Combined with COMP 443-001.
 
 
-:doc:`../courses/comp347` 
+:doc:`../courses/comp347`
     | Section 001 (6292) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -86,7 +86,7 @@ Undergraduate Courses
     Combined with COMP 447-001.
 
 
-:doc:`../courses/comp377` 
+:doc:`../courses/comp377`
     | Section 001 (6324) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45
@@ -111,7 +111,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp403` 
+:doc:`../courses/comp403`
     | Section 001 (6329) Credits: 3; In person; Lecture
     | Instructor: Channah Naiman
     | Corboy Law Center:0423 (Water Tower) Wednesday 07:00PM-09:30
@@ -119,7 +119,7 @@ Graduate Courses
 
 
 
-:doc:`../courses/comp424` 
+:doc:`../courses/comp424`
     | Section 001 (6377) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0105 (Water Tower) Tuesday 07:00PM-09:30
@@ -128,7 +128,7 @@ Graduate Courses
     Combined with COMP 324-001.
 
 
-:doc:`../courses/comp433` 
+:doc:`../courses/comp433`
     | Section 001 (6340) Credits: 3; In person; Lecture
     | Instructor: Berhane Zewdie
     | Corboy Law Center:0321 (Water Tower) Monday 07:00PM-09:30
@@ -137,7 +137,7 @@ Graduate Courses
     Combined with COMP 333-001.
 
 
-:doc:`../courses/comp436` 
+:doc:`../courses/comp436`
     | Section 001 (6341) Credits: 3; In person; Lecture
     | Instructor: Nicholas J Hayward
     | Corboy Law Center:0522 (Water Tower) Wednesday 04:15PM-06:45
@@ -146,7 +146,7 @@ Graduate Courses
     Combined with COMP 336-001.
 
 
-:doc:`../courses/comp443` 
+:doc:`../courses/comp443`
     | Section 001 (6342) Credits: 3; In person; Lecture
     | Instructor: Peter L Dordal
     | Corboy Law Center:0208 (Water Tower) Tuesday 04:15PM-06:45
@@ -155,7 +155,7 @@ Graduate Courses
     Combined with COMP 343-001.
 
 
-:doc:`../courses/comp447` 
+:doc:`../courses/comp447`
     | Section 001 (6358) Credits: 3; In person; Lecture
     | Instructor: Corby Schmitz
     | School of Communicat:013 (Water Tower) Friday 05:45PM-08:15
@@ -164,7 +164,7 @@ Graduate Courses
     Combined with COMP 347-001.
 
 
-:doc:`../courses/comp477` 
+:doc:`../courses/comp477`
     | Section 001 (6362) Credits: 3; In person; Lecture
     | Instructor: Conrad Weisert
     | Corboy Law Center:0523 (Water Tower) Monday 04:15PM-06:45

--- a/deprecated/watertowerspring.rst
+++ b/deprecated/watertowerspring.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 See `Textbook Information <https://docs.google.com/spreadsheets/d/14Hc2m97IDiBYxVjJ6Tz9kOz-RxWYl74LrBh8oj-7VR8/edit#gid=0>`_.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`watertowerspring_graduate_courses_list`.

--- a/deprecated/watertowersummer.rst
+++ b/deprecated/watertowersummer.rst
@@ -13,12 +13,12 @@ For open/full status and latest changes, see
 Textbook information will be linked in later.
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`watertowersummer_graduate_courses_list`.

--- a/scripts/Test.py
+++ b/scripts/Test.py
@@ -1,28 +1,31 @@
 import os
 import csv
 import datetime
+
 now = datetime.datetime.now()
+
+
 def parseing(fileName):
-	debugCounter = 0
-	sectionTemplate = '''
+    debugCounter = 0
+    sectionTemplate = """
 :doc:`{subject}{catNumber}`{SpTopic} {Term}
     | Section {section} ({classNumber}) Credits: {units}; {mixture}; {component}
     | Instructor: {Instructor}
     |{Building}:{Room} {Location} {Days} {Time}
 
 	{description}
-'''
+"""
 
-	sectionTemplateMultiRoom = '''
+    sectionTemplateMultiRoom = """
 :doc:`{subject}{catNumber}`{SpTopic} {Term}
     | Section {section} ({classNumber}) Credits: {units}; {mixture}; {component}
     | Instructor: {Instructor}
     {multiRoom}
 
 	{description}
-'''
+"""
 
-	sectionTemplateLab = '''
+    sectionTemplateLab = """
 :doc:`{subject}{catNumber}`{SpTopic} {Term}
     | Section {section}/{labSection} ({classNumber}) Credits: {units}; {mixture}; {component}
     | Instructor: {Instructor}
@@ -30,18 +33,18 @@ def parseing(fileName):
     |{labBuilding}: {labRoom} ({labLocation}) {labDay} {labTime} (lab)
 
 	{description}
-'''
+"""
 
-	comp314_315Template = '''
+    comp314_315Template = """
 	{subject}{catNumber} {Term} (Description: :doc:`comp314-315`)
 		| Section {section} ({classNumber}) Credits: {units}; {mixture}; {component}
 		| Instructor: {Instructor}
 	        |{Building}:{Room} {Location} {Days} {Time}
 
 	{description}
-	'''
+	"""
 
-	topicsSectionTemplate = '''
+    topicsSectionTemplate = """
 {subject}{catNumber} Topic{topics} {Term}
 	| Section {section} ({classNumber}) Credits: {units}; {mixture}; {component}
 	| Instructor: {Instructor}
@@ -49,9 +52,9 @@ def parseing(fileName):
 	| Description similar to: :doc:`{docName}`
 
 {description}
-'''
+"""
 
-	headerTemplate = '''
+    headerTemplate = """
 {semester} Schedule {txtURLline} {where}
 ==========================================================================
 {created}
@@ -68,9 +71,9 @@ See `Textbook Information {textBookURLline}`_.
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 {graduateLink}
@@ -84,346 +87,442 @@ Friday line(s) are likely to be isolated makeup days, not every week.
 {udergradeTxt}
 ~~~~~~~~~~~~~~~~~~~~~
 
-'''
+"""
 
-	gradHeadingTemplate = '''
+    gradHeadingTemplate = """
 
 .. _{0}_graduate_courses_list_{1}:
 
 Graduate Courses
 ~~~~~~~~~~~~~~~~~~~~~
 
-'''
+"""
 
-	indepStudyTemplate = '''
+    indepStudyTemplate = """
 :doc:`{}` 1-6 credits
 	You cannot register
 	yourself for an independenst study course!
 	You must find a faculty member who
 	agrees to supervisor the work that you outline and schedule together.  This
 	*supervisor arranges to get you registered*.  Possible supervisors are: full-time department faculty
-	'''
-	classes = []
-	headerObject = {'semester':'', 'textBookURLline':'<https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5uqFiPEO_Ftp0mzesnEF5IFU1685w3I/edit?usp=sharing>',
-		 'created':'', 'graduateLink':'', 'campusURLTemplateCuneo':'','season':'','udergradeTxt':'Undergraduate Courses', 'where':'', 'pages':'',
-		 'txtURLline':''}
-	object = {'subject':'','catNumber' : '', 'section':'', 'classNumber':'' , 'title':'','component':'',
-	'units':'', 'topics':'', 'Building' : '', 'Location':'', 'Room':'', 'Days':'',
-	'Time':'', 'Instructor':'', 'classCap':'','totalStudents':'', 'waitCap':'', 'waitTotal':'',
-	'minEnroll':'', 'Attributes':'', 'roomCharicteristics':'', 'CombinedSID':'', 'ClassEquiv':'',
-	'SpTopic':'', 'Term':'', 'mixture':'', 'description':'', 'hasLab':False, 'labBuilding':'', 'labRoom':'',
-	'labTime':'', 'labDay':'', 'labLocation':'', 'Term':'', 'isStudy':False, 'isMultiRoom':False, 'docName':'',
-	 'multiRoom':''}
-	file = open(fileName, 'r')
-	reader = csv.reader(file, delimiter=',')
-	LSBuildings = ['Cuneo', 'Mundelein', 'Crown', 'Sullivan', 'Life Science', 'Dumbach']
-	checker=0
-	string = ''
-	appendToList = False
-	hasLab = False
-	semester = ''
-	season = ''
-	for row in reader:
-		#print(row)
+	"""
+    classes = []
+    headerObject = {
+        "semester": "",
+        "textBookURLline": "<https://docs.google.com/spreadsheets/d/138_JN8WEP8Pv5uqFiPEO_Ftp0mzesnEF5IFU1685w3I/edit?usp=sharing>",
+        "created": "",
+        "graduateLink": "",
+        "campusURLTemplateCuneo": "",
+        "season": "",
+        "udergradeTxt": "Undergraduate Courses",
+        "where": "",
+        "pages": "",
+        "txtURLline": "",
+    }
+    object = {
+        "subject": "",
+        "catNumber": "",
+        "section": "",
+        "classNumber": "",
+        "title": "",
+        "component": "",
+        "units": "",
+        "topics": "",
+        "Building": "",
+        "Location": "",
+        "Room": "",
+        "Days": "",
+        "Time": "",
+        "Instructor": "",
+        "classCap": "",
+        "totalStudents": "",
+        "waitCap": "",
+        "waitTotal": "",
+        "minEnroll": "",
+        "Attributes": "",
+        "roomCharicteristics": "",
+        "CombinedSID": "",
+        "ClassEquiv": "",
+        "SpTopic": "",
+        "Term": "",
+        "mixture": "",
+        "description": "",
+        "hasLab": False,
+        "labBuilding": "",
+        "labRoom": "",
+        "labTime": "",
+        "labDay": "",
+        "labLocation": "",
+        "Term": "",
+        "isStudy": False,
+        "isMultiRoom": False,
+        "docName": "",
+        "multiRoom": "",
+    }
+    file = open(fileName, "r")
+    reader = csv.reader(file, delimiter=",")
+    LSBuildings = ["Cuneo", "Mundelein", "Crown", "Sullivan", "Life Science", "Dumbach"]
+    checker = 0
+    string = ""
+    appendToList = False
+    hasLab = False
+    semester = ""
+    season = ""
+    for row in reader:
+        # print(row)
 
-		for i in range(0, len(row)):
-			if "COMP" == row[0]:
-				object['subject'] = row[i].lower().strip()
-				object['catNumber'] = str(int(row[i+1]))
-				if object['catNumber'] == '398':
-					object['isStudy'] = True
-				object['section'] = row[i+2]
-				if 'L' in row[i+2]:
-					for m in range(0,len(classes)):
-						if classes[m]['catNumber'] == object['catNumber'] and classes[m]['section'] in object['section']:
-							classes[m]['hasLab'] = True
-							hasLab = True
-							classes[m]['labSection'] = row[i+2]
-				else:
-					object['section'] = row[i+2][1:]
+        for i in range(0, len(row)):
+            if "COMP" == row[0]:
+                object["subject"] = row[i].lower().strip()
+                object["catNumber"] = str(int(row[i + 1]))
+                if object["catNumber"] == "398":
+                    object["isStudy"] = True
+                object["section"] = row[i + 2]
+                if "L" in row[i + 2]:
+                    for m in range(0, len(classes)):
+                        if (
+                            classes[m]["catNumber"] == object["catNumber"]
+                            and classes[m]["section"] in object["section"]
+                        ):
+                            classes[m]["hasLab"] = True
+                            hasLab = True
+                            classes[m]["labSection"] = row[i + 2]
+                else:
+                    object["section"] = row[i + 2][1:]
 
-				object['classNumber'] = row[i+3]
-				object['title'] = row[i+4]
-				object['component'] = row[i+5]
-				object['units'] = row[i+6]
-				if i+7 <= len(row):
-					object['topics'] = row[i+7]
-					break
-				break
-			elif " Fall " in row[0]:
-				season = 'Fall'
-				semester = "Fall " + getYear(row[0].split(" "), season)
-				headerObject['season'] = season
-				headerObject['semester']= semester
-			elif " Spring " in row[0]:
-				season = 'Spring'
-				semester = "Spring " + getYear(row[0].split(" "), season)
-				headerObject['season'] = season
-				headerObject['semester']= semester
-			elif " Summer " in row[0]:
-				season = 'Summer'
-				semester = "Summer " + getYear(row[0].split(" "), season)
-				headerObject['season'] = season
-				headerObject['semester']= semester
-			elif 'Week' in row[0]:
-				object['Term'] = "[" + str(row[0]) + "]"
-			elif row[0] == 'Bldg:' and not hasLab:
-				if object['Building'] != '':
-					object['Building'] = object['Building'] + ' +' +str(row[i+1])
-					object['Room'] = object['Room'] +' + '+row[i+3]
-					object['Days']= str(object['Days']) +' + '+ str(convertDays(row[i+5]))
-					object['Time'] = object['Time'] +' + '+row[i+7]
-					for j in range(0, len(LSBuildings)):
-						if LSBuildings[j] in row[i+1]:
-							object['Location'] = '(Lake Shore)' + ' +' + object['Location']
-							break
-						if row[i+1] == 'TBA':
-							object["Location"] = '' + ' + ' + object['Location']
-							break
-						if 'Online' in row[i+1]:
-							object['Location'] =  '(Online)' + ' +' + object['Location']
-							break
-						if j == len(LSBuildings)-1:
-							object['Location'] = '(Water Tower)' + ' +' + object['Location']
+                object["classNumber"] = row[i + 3]
+                object["title"] = row[i + 4]
+                object["component"] = row[i + 5]
+                object["units"] = row[i + 6]
+                if i + 7 <= len(row):
+                    object["topics"] = row[i + 7]
+                    break
+                break
+            elif " Fall " in row[0]:
+                season = "Fall"
+                semester = "Fall " + getYear(row[0].split(" "), season)
+                headerObject["season"] = season
+                headerObject["semester"] = semester
+            elif " Spring " in row[0]:
+                season = "Spring"
+                semester = "Spring " + getYear(row[0].split(" "), season)
+                headerObject["season"] = season
+                headerObject["semester"] = semester
+            elif " Summer " in row[0]:
+                season = "Summer"
+                semester = "Summer " + getYear(row[0].split(" "), season)
+                headerObject["season"] = season
+                headerObject["semester"] = semester
+            elif "Week" in row[0]:
+                object["Term"] = "[" + str(row[0]) + "]"
+            elif row[0] == "Bldg:" and not hasLab:
+                if object["Building"] != "":
+                    object["Building"] = object["Building"] + " +" + str(row[i + 1])
+                    object["Room"] = object["Room"] + " + " + row[i + 3]
+                    object["Days"] = (
+                        str(object["Days"]) + " + " + str(convertDays(row[i + 5]))
+                    )
+                    object["Time"] = object["Time"] + " + " + row[i + 7]
+                    for j in range(0, len(LSBuildings)):
+                        if LSBuildings[j] in row[i + 1]:
+                            object["Location"] = (
+                                "(Lake Shore)" + " +" + object["Location"]
+                            )
+                            break
+                        if row[i + 1] == "TBA":
+                            object["Location"] = "" + " + " + object["Location"]
+                            break
+                        if "Online" in row[i + 1]:
+                            object["Location"] = "(Online)" + " +" + object["Location"]
+                            break
+                        if j == len(LSBuildings) - 1:
+                            object["Location"] = (
+                                "(Water Tower)" + " +" + object["Location"]
+                            )
 
-					object['isMultiRoom'] = True
-				else:
-					object['Building'] = row[i+1]
-					object['Room'] = row[i+3]
-					object['Days']= convertDays(row[i+5])
-					object['Time'] = row[i+7]
-					if 9 < len(row):
-						object['Instructor'] = row[9]
-					for j in range(0, len(LSBuildings)):
-						if LSBuildings[j] in object['Building']:
-							object['Location'] = '(Lake Shore)'
-							break
-						elif object["Building"] == 'TBA':
-							object["Location"] = ''
-							break
-						elif 'Online' in object["Building"]:
-							object['Location'] = '(Online)'
-							break
-						else:
-							object['Location'] = '(Water Tower)'
-				if object['Instructor'] == '':
-					object['Instructor'] = 'N/A'
-				break
-			elif row[0] == 'Bldg:' and hasLab:
-				for m in range(0,len(classes)):
-					if classes[m]['catNumber'] == object['catNumber'] and classes[m]['section'] in object['section']:
-						classes[m]['labBuilding'] = row[i+1]
-						waterTower = True
-						for j in range(0, len(LSBuildings)):
-							if LSBuildings[j] in classes[m]['labBuilding']:
-								classes[m]['labLocation'] = 'Lake Shore'
-								waterTower = False
-							elif classes[m]["labBuilding"] == 'TBA':
-								classes[m]["labLocation"] = ''
-								waterTower = False
-							elif classes[m]['labBuilding'] == 'Online':
-								classes[m]['labLocation'] = 'Online'
-								waterTower = False
-						if waterTower:
-							classes[m]['labLocation'] = 'Water Tower'
+                    object["isMultiRoom"] = True
+                else:
+                    object["Building"] = row[i + 1]
+                    object["Room"] = row[i + 3]
+                    object["Days"] = convertDays(row[i + 5])
+                    object["Time"] = row[i + 7]
+                    if 9 < len(row):
+                        object["Instructor"] = row[9]
+                    for j in range(0, len(LSBuildings)):
+                        if LSBuildings[j] in object["Building"]:
+                            object["Location"] = "(Lake Shore)"
+                            break
+                        elif object["Building"] == "TBA":
+                            object["Location"] = ""
+                            break
+                        elif "Online" in object["Building"]:
+                            object["Location"] = "(Online)"
+                            break
+                        else:
+                            object["Location"] = "(Water Tower)"
+                if object["Instructor"] == "":
+                    object["Instructor"] = "N/A"
+                break
+            elif row[0] == "Bldg:" and hasLab:
+                for m in range(0, len(classes)):
+                    if (
+                        classes[m]["catNumber"] == object["catNumber"]
+                        and classes[m]["section"] in object["section"]
+                    ):
+                        classes[m]["labBuilding"] = row[i + 1]
+                        waterTower = True
+                        for j in range(0, len(LSBuildings)):
+                            if LSBuildings[j] in classes[m]["labBuilding"]:
+                                classes[m]["labLocation"] = "Lake Shore"
+                                waterTower = False
+                            elif classes[m]["labBuilding"] == "TBA":
+                                classes[m]["labLocation"] = ""
+                                waterTower = False
+                            elif classes[m]["labBuilding"] == "Online":
+                                classes[m]["labLocation"] = "Online"
+                                waterTower = False
+                        if waterTower:
+                            classes[m]["labLocation"] = "Water Tower"
 
+                        classes[m]["labRoom"] = row[i + 3]
+                        classes[m]["labDay"] = convertDays(row[i + 5])
+                        classes[m]["labTime"] = row[i + 7]
+                break
+            elif row[0] == "Class Enrl Cap:":
+                object["classCap"] = row[i + 1]
+                object["totalStudents"] = row[i + 3]
+                object["waitCap"] = row[i + 5]
+                object["waitTotal"] = row[i + 7]
+                if i + 9 < len(row[i]):
+                    object["minEnroll"] = row[i + 9]
+                    break
+                break
+            elif row[0] == "Attributes:":
+                object["Attributes"] = row[1]
+            elif row[0] == "Room Characteristics:":
+                object["roomCharicteristics"] = row[i + 1]
+                break
+            elif row[0] == "Class Equivalents:":
+                if len(row) > i + 1:
+                    object["ClassEquiv"] = row[i + 1]
+            elif "Combined with" in row[0]:
+                tempList = row[0].split()
+                for q in range(0, len(tempList)):
+                    if "COMP" == tempList[q]:
+                        tempSplit = tempList[q + 1].split("-")
+                        classNum = tempSplit[0]
+                        object["docName"] = tempList[q].lower() + classNum
+            elif "_______" in row[0]:
+                if string != "":
+                    object["description"] = "**Notes**\n        " + string
+                string = ""
+                if hasLab == False:
+                    appendToList = True
+                hasLab = False
+                break
+            elif row[0] == "Combined Section ID:":
+                object["CombinedSID"] == row[1] + row[2] + row[3]
+                break
+            elif row[0] == "":
+                for q in range(0, len(row)):
+                    if row[q] != "":
+                        object["mixture"] = row[q]
+                        if object["mixture"] == "(Online)":
+                            object["Location"] = "(Online)"
+                            object["Building"] = "Online"
 
-						classes[m]['labRoom'] = row[i+3]
-						classes[m]['labDay']= convertDays(row[i+5])
-						classes[m]['labTime'] = row[i+7]
-				break
-			elif row[0] == 'Class Enrl Cap:':
-				object['classCap'] = row[i+1]
-				object['totalStudents'] = row[i+3]
-				object['waitCap'] = row[i+5]
-				object['waitTotal'] = row[i+7]
-				if i+9 < len(row[i]):
-					object['minEnroll'] = row[i+9]
-					break
-				break
-			elif row[0] == 'Attributes:':
-				object['Attributes'] = row[1]
-			elif row[0] == 'Room Characteristics:':
-				object['roomCharicteristics'] = row[i+1]
-				break
-			elif row[0] == "Class Equivalents:":
-				if len(row) > i+1:
-					object['ClassEquiv'] = row[i+1]
-			elif 'Combined with' in row[0]:
-				tempList = row[0].split()
-				for q in range(0,len(tempList)):
-					if 'COMP' == tempList[q]:
-						tempSplit = tempList[q+1].split('-')
-						classNum = tempSplit[0]
-						object['docName'] = tempList[q].lower() + classNum
-			elif '_______' in row[0]:
-				if string != '':
-					object['description'] = "**Notes**\n        " + string
-				string = ''
-				if hasLab == False:
-					appendToList = True
-				hasLab = False
-				break
-			elif row[0] == 'Combined Section ID:':
-				object['CombinedSID'] == row[1] + row[2]+row[3]
-				break
-			elif row[0] == '':
-				for q in range(0,len(row)):
-					if row[q] != '':
-						object['mixture'] = row[q]
-						if object['mixture'] == "(Online)":
-							object["Location"] = '(Online)'
-							object["Building"] = "Online"
+            else:
+                if row[i] != "":
+                    string += row[i] + "\n        "
+        if appendToList:
+            if "Report ID:" not in object["description"]:
+                classes.append(object)
+                # print(object)
+                # print(len(classes))
+            elif object["isStudy"]:
+                continue
 
-			else:
-				if row[i] != '':
-					string +=  row[i] + '\n        '
-		if appendToList:
-			if 'Report ID:' not in object['description']:
-				classes.append(object)
-				#print(object)
-				#print(len(classes))
-			elif object['isStudy']:
-				continue
-
-			object = object.fromkeys(object, '')
-			appendToList = False
-			object['Building'] = ''
-			object['Days'] = ''
-			object['Room'] = ''
-			object['Days']= ''
-			object['Time'] = ''
-			object['Location'] = ''
-	mainRST = open('./checkFolder/'+season.lower()+'.rst','w')
-	onlineRST = open('./checkFolder/online'+season.lower()+'.rst','w')
-	lakeRST = open('./checkFolder/lakeshore'+season.lower()+'.rst','w')
-	waterRST = open('./checkFolder/watertower'+season.lower()+'.rst','w')
-	headerObject['pages'] = '''
+            object = object.fromkeys(object, "")
+            appendToList = False
+            object["Building"] = ""
+            object["Days"] = ""
+            object["Room"] = ""
+            object["Days"] = ""
+            object["Time"] = ""
+            object["Location"] = ""
+    mainRST = open("./checkFolder/" + season.lower() + ".rst", "w")
+    onlineRST = open("./checkFolder/online" + season.lower() + ".rst", "w")
+    lakeRST = open("./checkFolder/lakeshore" + season.lower() + ".rst", "w")
+    waterRST = open("./checkFolder/watertower" + season.lower() + ".rst", "w")
+    headerObject[
+        "pages"
+    ] = """
 	* :doc:`lakeshore{0}`
 	* :doc:`watertower{0}`
-	* :doc:`online{0}`'''.format(season.lower())
-	mainRST.write(headerTemplate.format(**headerObject))
-	headerObject['where'] = '(Lake Shore)'
-	headerObject['pages'] = '''
+	* :doc:`online{0}`""".format(
+        season.lower()
+    )
+    mainRST.write(headerTemplate.format(**headerObject))
+    headerObject["where"] = "(Lake Shore)"
+    headerObject[
+        "pages"
+    ] = """
 	* :doc:`{0}`
 	* :doc:`watetower{0}`
-	* :doc:`online{0}`'''.format(season.lower())
-	lakeRST.write(headerTemplate.format(**headerObject))
-	headerObject['where'] = '(Online)'
-	headerObject['pages'] = '''
+	* :doc:`online{0}`""".format(
+        season.lower()
+    )
+    lakeRST.write(headerTemplate.format(**headerObject))
+    headerObject["where"] = "(Online)"
+    headerObject[
+        "pages"
+    ] = """
 	* :doc:`lakeshore{0}`
 	* :doc:`watertower{0}`
-	* :doc:`{0}`'''.format(season.lower())
-	onlineRST.write(headerTemplate.format(**headerObject))
-	headerObject['where'] = '(Water Tower)'
-	headerObject['pages'] = '''
+	* :doc:`{0}`""".format(
+        season.lower()
+    )
+    onlineRST.write(headerTemplate.format(**headerObject))
+    headerObject["where"] = "(Water Tower)"
+    headerObject[
+        "pages"
+    ] = """
 	* :doc:`lakeshore{0}`
 	* :doc:`{0}`
-	* :doc:`online{0}`'''.format(season.lower())
-	waterRST.write(headerTemplate.format(**headerObject))
-	Check398 = True
-	Check499 = True
-	Check490 = True
-	for k in range(0, len(classes)):
-		currentLine = ''
-		if classes[k]['hasLab']:
-			currentLine = sectionTemplateLab.format(**classes[k])
-		elif classes[k]['isMultiRoom']:
-			multiRoom = ''
-			bList = classes[k]['Building'].split('+')
-			dList = classes[k]['Days'].split('+')
-			rList = classes[k]['Room'].split('+')
-			lList = classes[k]['Location'].split('+')
-			tList = classes[k]['Time'].split('+')
-			for times in range(0, len(bList)):
-				multiRoom = multiRoom + "| {0}: {1} {2} {3} {4} \n    ".format(bList[times], rList[times],lList[times],dList[times],tList[times])
-			classes[k]['multiRoom'] = multiRoom
-			currentLine = sectionTemplateMultiRoom.format(**classes[k])
-		elif classes[k]['catNumber'] == '314' or classes[k]['catNumber'] == '315':
-			currentLine = comp314_315Template.format(**classes[k])
-		elif classes[k]['catNumber'] == '388' or classes[k]['catNumber'] == '488':
-			currentLine = topicsSectionTemplate.format(**classes[k])
-		elif '398' in classes[k]['catNumber']  or '499' in classes[k]['catNumber'] or '490' in classes[k]['catNumber'] :
-			if '398' in classes[k]['catNumber'] :
-				if Check398:
-					currentLine = indepStudyTemplate.format("398")
-					Check398 = False
-				else:
-					currentLine = 0
-			if '490' in classes[k]['catNumber'] :
-				if Check499:
-					currentLine = indepStudyTemplate.format("499")
-					Check499 = False
-				else:
-					currentLine = 0
-			if '499' in classes[k]['catNumber']:
-				if Check490:
-					currentLine = indepStudyTemplate.format("490")
-					Check490 = False
-				else:
-					currentLine = 0
-		else:
-			currentLine = sectionTemplate.format(**classes[k])
-		createHeading = False
-		if int(classes[k-1]['catNumber']) < 400 and int(classes[k]['catNumber']) >= 400:
-			createHeading = True
+	* :doc:`online{0}`""".format(
+        season.lower()
+    )
+    waterRST.write(headerTemplate.format(**headerObject))
+    Check398 = True
+    Check499 = True
+    Check490 = True
+    for k in range(0, len(classes)):
+        currentLine = ""
+        if classes[k]["hasLab"]:
+            currentLine = sectionTemplateLab.format(**classes[k])
+        elif classes[k]["isMultiRoom"]:
+            multiRoom = ""
+            bList = classes[k]["Building"].split("+")
+            dList = classes[k]["Days"].split("+")
+            rList = classes[k]["Room"].split("+")
+            lList = classes[k]["Location"].split("+")
+            tList = classes[k]["Time"].split("+")
+            for times in range(0, len(bList)):
+                multiRoom = multiRoom + "| {0}: {1} {2} {3} {4} \n    ".format(
+                    bList[times], rList[times], lList[times], dList[times], tList[times]
+                )
+            classes[k]["multiRoom"] = multiRoom
+            currentLine = sectionTemplateMultiRoom.format(**classes[k])
+        elif classes[k]["catNumber"] == "314" or classes[k]["catNumber"] == "315":
+            currentLine = comp314_315Template.format(**classes[k])
+        elif classes[k]["catNumber"] == "388" or classes[k]["catNumber"] == "488":
+            currentLine = topicsSectionTemplate.format(**classes[k])
+        elif (
+            "398" in classes[k]["catNumber"]
+            or "499" in classes[k]["catNumber"]
+            or "490" in classes[k]["catNumber"]
+        ):
+            if "398" in classes[k]["catNumber"]:
+                if Check398:
+                    currentLine = indepStudyTemplate.format("398")
+                    Check398 = False
+                else:
+                    currentLine = 0
+            if "490" in classes[k]["catNumber"]:
+                if Check499:
+                    currentLine = indepStudyTemplate.format("499")
+                    Check499 = False
+                else:
+                    currentLine = 0
+            if "499" in classes[k]["catNumber"]:
+                if Check490:
+                    currentLine = indepStudyTemplate.format("490")
+                    Check490 = False
+                else:
+                    currentLine = 0
+        else:
+            currentLine = sectionTemplate.format(**classes[k])
+        createHeading = False
+        if (
+            int(classes[k - 1]["catNumber"]) < 400
+            and int(classes[k]["catNumber"]) >= 400
+        ):
+            createHeading = True
 
-		if currentLine != 0:
-			if 'Lake' in classes[k]['Location']:
-				if createHeading:
-					lcurrentLine = gradHeadingTemplate.format(season, 'Lake Shore') + '\n' + currentLine
-					lakeRST.write(lcurrentLine+'\n')
-				else:
-					lakeRST.write(currentLine+'\n')
-			if 'Water' in classes[k]['Location']:
-				if createHeading:
-					wcurrentLine = gradHeadingTemplate.format(season, 'Water Tower') + '\n' + currentLine
-					waterRST.write(wcurrentLine+'\n')
-				else:
-					waterRST.write(currentLine+'\n')
-			if 'Online' in classes[k]['Location']:
-				if createHeading:
-					ocurrentLine = gradHeadingTemplate.format(season, 'Online') + '\n' + currentLine
-					onlineRST.write(ocurrentLine+'\n')
-				else:
-					onlineRST.write(currentLine+'\n')
-			if createHeading:
-				fcurrentLine = gradHeadingTemplate.format(season, 'Fall') + '\n' + currentLine
-				mainRST.write(fcurrentLine+'\n')
-			else:
-				mainRST.write(currentLine+'\n')
+        if currentLine != 0:
+            if "Lake" in classes[k]["Location"]:
+                if createHeading:
+                    lcurrentLine = (
+                        gradHeadingTemplate.format(season, "Lake Shore")
+                        + "\n"
+                        + currentLine
+                    )
+                    lakeRST.write(lcurrentLine + "\n")
+                else:
+                    lakeRST.write(currentLine + "\n")
+            if "Water" in classes[k]["Location"]:
+                if createHeading:
+                    wcurrentLine = (
+                        gradHeadingTemplate.format(season, "Water Tower")
+                        + "\n"
+                        + currentLine
+                    )
+                    waterRST.write(wcurrentLine + "\n")
+                else:
+                    waterRST.write(currentLine + "\n")
+            if "Online" in classes[k]["Location"]:
+                if createHeading:
+                    ocurrentLine = (
+                        gradHeadingTemplate.format(season, "Online")
+                        + "\n"
+                        + currentLine
+                    )
+                    onlineRST.write(ocurrentLine + "\n")
+                else:
+                    onlineRST.write(currentLine + "\n")
+            if createHeading:
+                fcurrentLine = (
+                    gradHeadingTemplate.format(season, "Fall") + "\n" + currentLine
+                )
+                mainRST.write(fcurrentLine + "\n")
+            else:
+                mainRST.write(currentLine + "\n")
 
-	mainRST.close()
-	onlineRST.close()
-	lakeRST.close()
-	waterRST.close()
+    mainRST.close()
+    onlineRST.close()
+    lakeRST.close()
+    waterRST.close()
+
 
 def convertDays(days):
-	if days == 'M':
-		return 'Monday'
-	if days == 'Tu':
-		return 'Tuesday'
-	if days == 'W':
-		return 'Wednesday'
-	if days == 'Th':
-		return 'Thursday'
-	if days == 'F':
-		return 'Friday'
-	if days == 'Sa':
-		return 'Saturday'
-	if days == 'MWF':
-		return 'Monday, Wednesday, Friday'
-	if days == 'TuTh':
-		return 'Tuesday, Thursday'
-	if days == 'MW':
-		return 'Monday, Wednesday'
-#the first few lines of the csv have the semester and yearself.
-#once the parser gets to that row it parses it looking for the year.
+    if days == "M":
+        return "Monday"
+    if days == "Tu":
+        return "Tuesday"
+    if days == "W":
+        return "Wednesday"
+    if days == "Th":
+        return "Thursday"
+    if days == "F":
+        return "Friday"
+    if days == "Sa":
+        return "Saturday"
+    if days == "MWF":
+        return "Monday, Wednesday, Friday"
+    if days == "TuTh":
+        return "Tuesday, Thursday"
+    if days == "MW":
+        return "Monday, Wednesday"
+
+
+# the first few lines of the csv have the semester and yearself.
+# once the parser gets to that row it parses it looking for the year.
 def getYear(words, season):
-	for i in range (0, len(words)):
-		if words[i] == season:
-			return words[i+1]
-	return str(now.year)
+    for i in range(0, len(words)):
+        if words[i] == season:
+            return words[i + 1]
+    return str(now.year)
+
 
 name = input("Enter file name.")
 parseing(name)

--- a/scripts/csv2sched.py
+++ b/scripts/csv2sched.py
@@ -1,9 +1,9 @@
-'''script to take csv file from Locus class schedule and make
+"""script to take csv file from LOCUS class schedule and make
 nice .rst files for all courses or those filtered by campus
 Assumes <Season><year>.txt file contains texts link or info - maybe more later
 Works for Fall, Spring, and Summer
-though summer may not be set up in index or T4 
-'''
+though summer may not be set up in index or T4
+"""
 
 from csv import reader
 
@@ -32,11 +32,11 @@ from csv import reader
 # Parts are terminated with separator line starting with many dashes
 #   Two types:  page heading and course sections
 # All extracted in parseCSV
-# Different semester types and campuses are in different pages, 
+# Different semester types and campuses are in different pages,
 #    so grabbed from latest page heading:
-        # semester type, either regular... or like 7 week - first 
-        # enclosing semester like Spring 2019
-        # created on csv creation date, time
+# semester type, either regular... or like 7 week - first
+# enclosing semester like Spring 2019
+# created on csv creation date, time
 # Section complications:  multiple date formats, multiple instructors
 #    Section data extracted in Section constructor, dict remembered
 #         See Section class for more documentation
@@ -50,45 +50,49 @@ import os, os.path
 import argparse
 
 logList = []
-campuses = ['Lake Shore', 'Watertower', 'Online'] 
-TESTPREFIX = '' # 'TEST' #DEBUG
+campuses = ["Lake Shore", "Watertower", "Online"]
+TESTPREFIX = ""  # 'TEST' #DEBUG
+
 
 def log(s):
     logList.append(s)
 
+
 def printLog():
     if logList:
-        print('\n\nLogged items: ')
+        print("\n\nLogged items: ")
         for s in logList:
             print(s)
 
+
 ############# support making .rst ########
 def joinIndented(lines, indent):
-    'lines is a list of lines.  Return lines indented in one string for .rst'
-    if not lines:  return ''
+    "lines is a list of lines.  Return lines indented in one string for .rst"
+    if not lines:
+        return ""
     lines = [indent + line.strip() for line in lines]
-    return '\n'.join(lines)
+    return "\n".join(lines)
 
 
-sectionTemplate = '''
+sectionTemplate = """
 :doc:`{docName}`{topic} {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
     | Instructor: {instructor}
 {placeTimes}
 
 {notes}
-''' # docName link should give full course title - so not 388/488
+"""  # docName link should give full course title - so not 388/488
 
-comp314_315Template = '''
+comp314_315Template = """
 {area} {number} {term} (Description: :doc:`comp314-315`)
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
     | Instructor: {instructor}
 {placeTimes}
 
 {notes}
-'''
+"""
 
-topicsSectionTemplate = '''
+topicsSectionTemplate = """
 
 {area} {number} Topic {topic} {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
@@ -97,41 +101,44 @@ topicsSectionTemplate = '''
     | Description similar to: :doc:`{docName}`
 
 {notes}
-'''      # 388/488  handles links to descritions differently
+"""  # 388/488  handles links to descritions differently
 
 ################## Section class for all section data ##############
-class Section:  
-    '''Has members (example in paren)
-      campus (Online, Lakshore, Watertower, Cuneo)
-      term  (regular is '', 8 Week 1)
-      instructor (Willaim Honig)
-      instructorList(['Honig, William'])
-      area (COMP)
-      number (170)
-      section (002 or 02L)
-      regCode (4235)
-      title (Introduction to Computing) not used, but check?
-      format (Lecture or Laboratory)
-      credits (3 or 1-6)
-      topic (Foundations of Computer Science I - for 388, 488)
-      mixture (In person, Hybrid, Online)
-      placeTimes (indented string lines from list of place-days-time-campus)
-      notes (indented string of lines)
-      crsAbbr (comp150)
-      abbr (comp150-001)
-      docName (comp150 or special for topics course section))
-    '''
-    def __init__(self, campus, term, lines, indent = ' '*4): # see .csv example for locations!
+class Section:
+    """Has members (example in paren)
+    campus (Online, Lakshore, Watertower, Cuneo)
+    term  (regular is '', 8 Week 1)
+    instructor (Willaim Honig)
+    instructorList(['Honig, William'])
+    area (COMP)
+    number (170)
+    section (002 or 02L)
+    regCode (4235)
+    title (Introduction to Computing) not used, but check?
+    format (Lecture or Laboratory)
+    credits (3 or 1-6)
+    topic (Foundations of Computer Science I - for 388, 488)
+    mixture (In person, Hybrid, Online)
+    placeTimes (indented string lines from list of place-days-time-campus)
+    notes (indented string of lines)
+    crsAbbr (comp150)
+    abbr (comp150-001)
+    docName (comp150 or special for topics course section))
+    """
+
+    def __init__(
+        self, campus, term, lines, indent=" " * 4
+    ):  # see .csv example for locations!
         self.campus = campus
         self.term = term
-        if lines[2][-1].strip() != 'Instructor:': # may be no field for instructor
+        if lines[2][-1].strip() != "Instructor:":  # may be no field for instructor
             firstInstructor = lines[2][-1]
         else:
-            firstInstructor = 'Staff'
+            firstInstructor = "Staff"
         self.instructorList = [firstInstructor]
         self.area = lines[0][0].strip()
-        if self.area != 'COMP':
-            log('bad line 0:'+lines[0][0])
+        if self.area != "COMP":
+            log("bad line 0:" + lines[0][0])
         self.number = lines[0][1].strip()
         self.section = lines[0][2].strip()
         self.regCode = lines[0][3].strip()
@@ -139,160 +146,194 @@ class Section:
         self.format = lines[0][5].strip()
         self.credits = lines[0][6].strip()
         self.topic = lines[0][7].strip()
-        if self.topic:  self.topic = ': ' + self.topic
+        if self.topic:
+            self.topic = ": " + self.topic
         self.mixture = lines[1][-1].strip()[1:-1]
         self.crsAbbr = self.area.lower() + self.number  # just course
-        self.abbr = self.crsAbbr + '-' + self.section   # with section
+        self.abbr = self.crsAbbr + "-" + self.section  # with section
         self.setDocName()
-        placeTimeList = [] #allow multiple lines
+        placeTimeList = []  # allow multiple lines
         i = 2
-        lastFriLoc = '' # for courses with makeup Friday - does not find actual dates
-        while lines[i] and lines[i][0] == 'Bldg:':
+        lastFriLoc = ""  # for courses with makeup Friday - does not find actual dates
+        while lines[i] and lines[i][0] == "Bldg:":
             loc = getPlaceTime(lines[i], campus)
             # assume short term Fridays as later entrues are special, not all term.
-            if i>2 and self.term and ', Friday' not in loc and 'Friday' in loc:
+            if i > 2 and self.term and ", Friday" not in loc and "Friday" in loc:
                 if lastFriLoc != loc:
-                    placeTimeList.append(loc + ' - Check week(s)')
+                    placeTimeList.append(loc + " - Check week(s)")
                 lastFriLoc = loc
             else:
                 placeTimeList.append(loc)
             i += 1
-            if len(lines[i-1]) == len(lines[i]) and not lines[i][0]: # further instr under orig, empty fields before
+            if (
+                len(lines[i - 1]) == len(lines[i]) and not lines[i][0]
+            ):  # further instr under orig, empty fields before
                 if lines[i][-1] and lines[i][-1] not in self.instructorList:
-                     self.instructorList.append(lines[i][-1])
+                    self.instructorList.append(lines[i][-1])
                 i += 1
 
-        self.placeTimes = joinIndented(placeTimeList, indent + '| ')  # force separate lines
+        self.placeTimes = joinIndented(
+            placeTimeList, indent + "| "
+        )  # force separate lines
         self.instructorList.sort()
-        self.instructor = ', '.join([parse_instructor(instr) for instr in self.instructorList])
-        if lines[i] and lines[i][0] == 'Class Enrl Cap:': #look for more unused line types in future
+        self.instructor = ", ".join(
+            [parse_instructor(instr) for instr in self.instructorList]
+        )
+        if (
+            lines[i] and lines[i][0] == "Class Enrl Cap:"
+        ):  # look for more unused line types in future
             i += 1
-        if lines[i] and (lines[i][0] == 'Class Equivalents:' or lines[i][0] == 'Attributes:'):
+        if lines[i] and (
+            lines[i][0] == "Class Equivalents:" or lines[i][0] == "Attributes:"
+        ):
             i += 1
-        if lines[i] and (lines[i][0] == 'Room Characteristics:' or lines[i][0] == 'Class Equivalents:'):
+        if lines[i] and (
+            lines[i][0] == "Room Characteristics:"
+            or lines[i][0] == "Class Equivalents:"
+        ):
             i += 1
-        if lines[i] and lines[i][0]: # in case another line, not all empties
+        if lines[i] and lines[i][0]:  # in case another line, not all empties
             i += 1
         # ',,,,,,' line before notes,and notes are at the end:  process the rest
-        notes = [line[0] if line else '' for line in lines[i:-1] ] # skip dashes line at end
+        notes = [
+            line[0] if line else "" for line in lines[i:-1]
+        ]  # skip dashes line at end
 
         if notes:
-            notes[0] = '**Notes:** ' + notes[0].strip()
+            notes[0] = "**Notes:** " + notes[0].strip()
         self.notes = joinIndented(notes, indent).rstrip()
 
-    def setDocName(self): # this is the course with documentation - may be different for 388/488
-        #assume 388/488 convention for section > 100, section is corresponding linked course
-        specialSect = { '502': '305'
-                      }                               ## todo: make not hardcoded, need now?
+    def setDocName(
+        self,
+    ):  # this is the course with documentation - may be different for 388/488
+        # assume 388/488 convention for section > 100, section is corresponding linked course
+        specialSect = {"502": "305"}  ## todo: make not hardcoded, need now?
         self.docName = self.crsAbbr
-        if self.crsAbbr in ['comp388', 'comp488']:
+        if self.crsAbbr in ["comp388", "comp488"]:
             if specialSect.get(self.section):
-                self.docName = 'comp' + specialSect[self.section]
-            elif '500' > self.section >= '100':
-                self.docName = 'comp' + self.section
+                self.docName = "comp" + specialSect[self.section]
+            elif "500" > self.section >= "100":
+                self.docName = "comp" + self.section
             else:
-                self.docName = 'No comparison'  # KLUDGE for toSectRST (next function)!
-
+                self.docName = "No comparison"  # KLUDGE for toSectRST (next function)!
 
     def toSectRST(self):  # this section to .rst lines
-        if self.crsAbbr in ['comp314', 'comp315']:
+        if self.crsAbbr in ["comp314", "comp315"]:
             return comp314_315Template.format(**self.__dict__)
-        if self.crsAbbr == self.docName: # not 388/488
+        if self.crsAbbr == self.docName:  # not 388/488
             return sectionTemplate.format(**self.__dict__)
         s = topicsSectionTemplate.format(**self.__dict__)
-        if 'No comparison' in s:    # KLUDGE!
-            s = s.replace('''    | Description similar to: :doc:`No comparison`''', '')
+        if "No comparison" in s:  # KLUDGE!
+            s = s.replace("""    | Description similar to: :doc:`No comparison`""", "")
         return s
 
-    def __lt__(self, other): # so list in course  and section order
+    def __lt__(self, other):  # so list in course  and section order
         return self.abbr < other.abbr
+
 
 ############ support Section field formating ###########
 
+
 def getPlaceTime(line, campus):
-    'Return string for place, time, campus; online, TBA treated specially'
+    "Return string for place, time, campus; online, TBA treated specially"
     bldg = line[1].strip()
     room = line[3].strip()
     days = parse_days(line[5])
     clock = line[7].strip()
-    if clock == 'TBA':
-        time = 'Times: TBA'
+    if clock == "TBA":
+        time = "Times: TBA"
     else:
-        time = days + ' ' + clock
-    if campus == 'Online':
-        return 'Online ' + time
-    if room == 'TBA':
-        place = 'Place TBA'
+        time = days + " " + clock
+    if campus == "Online":
+        return "Online " + time
+    if room == "TBA":
+        place = "Place TBA"
     else:
-        place = bldg+ ':' + room
-    return '{} ({}) {}'.format(place, campus, time)
+        place = bldg + ":" + room
+    return "{} ({}) {}".format(place, campus, time)
+
 
 def parse_days(days):
-    'Remove day abbreviations: MWF -> Monday, Wednesday, Friday'
+    "Remove day abbreviations: MWF -> Monday, Wednesday, Friday"
     days = days.strip()
-    if days in ['See Note', 'TBA']:
-       return days
+    if days in ["See Note", "TBA"]:
+        return days
     orig = days
     full = []
-    for (abbr, day) in [('M', 'Monday'), ('Tu', 'Tuesday'), ('W', 'Wednesday'),
-                            ('Th', 'Thursday'), ('F', 'Friday'), ('Sa', 'Saturday')]:
+    for (abbr, day) in [
+        ("M", "Monday"),
+        ("Tu", "Tuesday"),
+        ("W", "Wednesday"),
+        ("Th", "Thursday"),
+        ("F", "Friday"),
+        ("Sa", "Saturday"),
+    ]:
         if abbr in days:
             full.append(day)
-            days = days.replace(abbr, '')
+            days = days.replace(abbr, "")
     if days or not orig:
-        log('Bad days code ' + orig)
-        return 'TBA'
-    return ', '.join(full)
+        log("Bad days code " + orig)
+        return "TBA"
+    return ", ".join(full)
+
 
 # decodes the instructor names putting them in order: "Smith,Adam" = Adam Smith
 def parse_instructor(instructor):
-    parts = instructor.split(',')
-    if '' in parts:   # not sure why this
-        return 'TBA'
+    parts = instructor.split(",")
+    if "" in parts:  # not sure why this
+        return "TBA"
     else:
         parts.reverse()
-        return ' '.join(parts)
+        return " ".join(parts)
+
 
 ############## for 391/490 special - single nentry with list of instructors
 
-indepStudyTemplate = '''
+indepStudyTemplate = """
 :doc:`{}` 1-6 credits
     You cannot register
     yourself for an independent study course!
     You must find a faculty member who
     agrees to supervisor the work that you outline and schedule together.  This
     *supervisor arranges to get you registered*.  Possible supervisors are: {}
-'''
+"""
+
 
 def getFacNames(crsAbbr, courses):  # all faculty of indep study sections together
     names = []
     for section in courses:
         if courses[section].crsAbbr == crsAbbr:
-           names += courses[section].instructorList
-    names = [name for name in names if name != 'Staff']
+            names += courses[section].instructorList
+    names = [name for name in names if name != "Staff"]
     names.sort()  # name last-first for sorting
     names = [parse_instructor(name) for name in names]
     if names:
-        return ', '.join(names)
-    return  'full-time department faculty'   #KLUDGE until names added
+        return ", ".join(names)
+    return "full-time department faculty"  # KLUDGE until names added
+
 
 ############## collapse lab sections into main #######
 
-def fixLabs(courses): # shorten by listing labs with main course section, deleting lab entry
+
+def fixLabs(
+    courses,
+):  # shorten by listing labs with main course section, deleting lab entry
     for name, sect in list(courses.items()):
-        if sect.section.endswith('L'):
-            mainAbbr = name.replace('-', '-0')[:-1] # comp170-02L -> comp170-002
+        if sect.section.endswith("L"):
+            mainAbbr = name.replace("-", "-0")[:-1]  # comp170-02L -> comp170-002
             mainSect = courses.get(mainAbbr)
             if mainSect:
-                mainSect.format += '/Lab'
-                mainSect.placeTimes += '\n' + sect.placeTimes + ' (lab)'
-                mainSect.section += '/' + sect.section
-                del(courses[name])
+                mainSect.format += "/Lab"
+                mainSect.placeTimes += "\n" + sect.placeTimes + " (lab)"
+                mainSect.section += "/" + sect.section
+                del courses[name]
+
 
 ########### more support for .rst file ########
 
+
 def doLevelRST(names, indep, rstParts, courses):
-    'Assemble grad or undergrad part with special independent study entry'
+    "Assemble grad or undergrad part with special independent study entry"
     names.sort()
     for sect in names:
         if sect == indep:
@@ -303,21 +344,22 @@ def doLevelRST(names, indep, rstParts, courses):
             if course:  # so not deleted lab section  # now deleted earlier - need?
                 rstParts.append(course.toSectRST())
 
-def campSeasonToDocName(camp, season): # campus and season make the document name 
-    camp = camp.replace(' ', '');
+
+def campSeasonToDocName(camp, season):  # campus and season make the document name
+    camp = camp.replace(" ", "")
     return TESTPREFIX + (camp + season).lower()
 
 
-def toAllRST(courses, semester, created, mainCampus, textURL=''):
-    '''return the entire rst file contents
+def toAllRST(courses, semester, created, mainCampus, textURL=""):
+    """return the entire rst file contents
     courses:  courses[abbr] = section
     semester:  like Fall 2019
     created:  Updated csv date and time
     mainCampus:  '' means all, or Lake Shore, Watertower, Online
     textURL URL or note to show about later text link
-    '''
+    """
 
-    headingTemplate = '''
+    headingTemplate = """
 {semester} Schedule {specialFilter}
 ==========================================================================
 {created}
@@ -332,12 +374,12 @@ For open/full status and latest changes, see
 {txtBookURLline}
 
 Section titles lines link to the course description page,
-except for special topics courses.  
+except for special topics courses.
 Some of those later show a link to a related course description.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 You can skip over undergrad courses to :ref:`{gradTarget}`.
@@ -353,182 +395,213 @@ You can skip over undergrad courses to :ref:`{gradTarget}`.
 Undergraduate Courses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-'''  # verbiage for top of each schedule
+"""  # verbiage for top of each schedule
 
-    gradHeadingTemplate = '''
+    gradHeadingTemplate = """
 
 .. _{gradTarget}:
 
 Graduate Courses
 ~~~~~~~~~~~~~~~~~~~~~
 
-''' # target  and headinf ofr html target
+"""  # target  and headinf ofr html target
 
     # heading insertions
     season = semester.split()[0].lower()
-    txtBookURLTemplate= 'See `Textbook Information <{textURL}>`_.'
-    txtBookURLline = ('See `Textbook Information <{}>`_.'.format(textURL) if '://' in textURL
-                      else textURL)
+    txtBookURLTemplate = "See `Textbook Information <{textURL}>`_."
+    txtBookURLline = (
+        "See `Textbook Information <{}>`_.".format(textURL)
+        if "://" in textURL
+        else textURL
+    )
     thisDoc = campSeasonToDocName(mainCampus, season)
-    undergradTarget = thisDoc + '_undergraduate_courses_list'
-    gradTarget = thisDoc + '_graduate_courses_list'
+    undergradTarget = thisDoc + "_undergraduate_courses_list"
+    gradTarget = thisDoc + "_graduate_courses_list"
 
-    if mainCampus == 'Online':
-        specialFilter = '( Online )'
+    if mainCampus == "Online":
+        specialFilter = "( Online )"
     elif mainCampus:
-        specialFilter = '( {} Campus )'.format(mainCampus)
+        specialFilter = "( {} Campus )".format(mainCampus)
     else:
-        specialFilter = ''
+        specialFilter = ""
 
-    campusURLTemplate= '' # set up other campuses for links
-    for camp in [''] + campuses:
-        if camp !=  mainCampus:
-            campusURLTemplate += '\n* :doc:`{}`'.format(campSeasonToDocName(camp, season))
+    campusURLTemplate = ""  # set up other campuses for links
+    for camp in [""] + campuses:
+        if camp != mainCampus:
+            campusURLTemplate += "\n* :doc:`{}`".format(
+                campSeasonToDocName(camp, season)
+            )
 
-    parts = [headingTemplate.format(**locals())] # make heading
+    parts = [headingTemplate.format(**locals())]  # make heading
 
-    abbrFilt = [abbr for (abbr, section) in courses.items() # filter sections
-                    if mainCampus in section.campus]
-    # add undergrad part                
-    undergrad = ['comp398'] + [abbr for abbr in abbrFilt   # one placeholder for 398
-                               if courses[abbr].area == 'COMP' and
-                                  '398' != courses[abbr].number < '400']
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    abbrFilt = [
+        abbr
+        for (abbr, section) in courses.items()  # filter sections
+        if mainCampus in section.campus
+    ]
+    # add undergrad part
+    undergrad = ["comp398"] + [
+        abbr
+        for abbr in abbrFilt  # one placeholder for 398
+        if courses[abbr].area == "COMP" and "398" != courses[abbr].number < "400"
+    ]
+    doLevelRST(undergrad, "comp398", parts, courses)
 
     # add grad part
     parts.append(gradHeadingTemplate.format(**locals()))
-    grad = ['comp490'] + [abbr for abbr in abbrFilt  # one placeholder for 490
-                          if courses[abbr].area == 'COMP' and
-                             '490' != courses[abbr].number >= '400']
-    doLevelRST(grad, 'comp490', parts, courses)
+    grad = ["comp490"] + [
+        abbr
+        for abbr in abbrFilt  # one placeholder for 490
+        if courses[abbr].area == "COMP" and "490" != courses[abbr].number >= "400"
+    ]
+    doLevelRST(grad, "comp490", parts, courses)
 
-    return '\n'.join(parts)
+    return "\n".join(parts)
+
 
 ############# for parsing ####################
 
+
 def getLines(rawLines):
-    '''return csv list of entries for each line,
-    If rawLines is a string it is taken as a csv file name'''
+    """return csv list of entries for each line,
+    If rawLines is a string it is taken as a csv file name"""
     if isinstance(rawLines, str):
         with open(rawLines) as inf:
             lines = list(reader(inf))
-        #printLines(lines, 15)
+        # printLines(lines, 15)
         return lines
     return list(reader(rawLines))
 
 
-def isDashes(s): # recognize csv part separator
-    return s.startswith('_____________')
+def isDashes(s):  # recognize csv part separator
+    return s.startswith("_____________")
 
-def getToDashes(lines): # section lines through EOF or ending dashes
+
+def getToDashes(lines):  # section lines through EOF or ending dashes
     part = []
     while lines:
-        line = lines.pop() # line is list from the comma separated list
+        line = lines.pop()  # line is list from the comma separated list
         part.append(line)
         if line and isDashes(line[0]):
-            return part               # so dashes line at end of what returned
+            return part  # so dashes line at end of what returned
     return None
 
 
 def parseCSV(csvFile):
-    '''return dictionary of courses, semester heading data'''
+    """return dictionary of courses, semester heading data"""
     lines = getLines(csvFile)
     lines.reverse()
-    #printLines(lines, -15) #DEBUG
+    # printLines(lines, -15) #DEBUG
     courses = {}
-    campus = 'Not set'  # like Lake Shore
-    term = 'Not set'  # empty for default main session, or like Seven Week - First
-    semester = 'Not set' # like Spring 2019
-    created = 'Not set'  # csv creation: Updated: date and time
+    campus = "Not set"  # like Lake Shore
+    term = "Not set"  # empty for default main session, or like Seven Week - First
+    semester = "Not set"  # like Spring 2019
+    created = "Not set"  # csv creation: Updated: date and time
 
-    while(lines):  # one part through dashes at a time
+    while lines:  # one part through dashes at a time
         part = getToDashes(lines)
         if part is None:
-            #print('At end!') #DEBUG
+            # print('At end!') #DEBUG
             return (courses, semester, created)
-        #print('Current section: ') #DEBUG
-        #for line in part: #DEBUG
+        # print('Current section: ') #DEBUG
+        # for line in part: #DEBUG
         #    print(line)
-        if part[-1][-1] == 'Topics': # page header
-            if not part[0][0]:  #empty commas at start for all but first page
+        if part[-1][-1] == "Topics":  # page header
+            if not part[0][0]:  # empty commas at start for all but first page
                 part = part[1:]
-            #print('Parsing page', part[0][3], 'semester', part[1][0]) #DEBUG
-            semester = ' '.join(part[1][0].split()[-2:]) # last two words of first entry in second line
+            # print('Parsing page', part[0][3], 'semester', part[1][0]) #DEBUG
+            semester = " ".join(
+                part[1][0].split()[-2:]
+            )  # last two words of first entry in second line
             date = part[1][2]
             time = part[2][2]
-            campus = part[2][0].partition('Location')[0].strip().replace('Campus: ', '').replace(' Campus', '')
+            campus = (
+                part[2][0]
+                .partition("Location")[0]
+                .strip()
+                .replace("Campus: ", "")
+                .replace(" Campus", "")
+            )
             # print(campus)  #DEBUG
             # assume campus and location same?
-            term = part[3][0] # empty string for regular session
+            term = part[3][0]  # empty string for regular session
 
-            if term == 'Regular Academic Session': # less verbose omitting standard session
-            	term = ''
+            if (
+                term == "Regular Academic Session"
+            ):  # less verbose omitting standard session
+                term = ""
             if term:
-                term = '[Term: ' + term + ']'
-            created = 'Updated {} {}'.format(date, time)
-            #not in use
-            #if not term and part[3][6] != 'Regular Academic Session':
-              # term = '[Term: ' + part[3][6] + ']'
+                term = "[Term: " + term + "]"
+            created = "Updated {} {}".format(date, time)
+            # not in use
+            # if not term and part[3][6] != 'Regular Academic Session':
+            # term = '[Term: ' + part[3][6] + ']'
         else:  # part is section description
-            #print('Processing section') #DEBUG
+            # print('Processing section') #DEBUG
             section = Section(campus, term, part)
             courses[section.abbr] = section
-        #input('press return: ')  #DEBUG
+        # input('press return: ')  #DEBUG
+
 
 def get_argparse():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--csv-file', help="load CSV file", required=True)
-    parser.add_argument('--dest-dir', help="where to write files", default=os.getcwd())
+    parser.add_argument("--csv-file", help="load CSV file", required=True)
+    parser.add_argument("--dest-dir", help="where to write files", default=os.getcwd())
     return parser
+
 
 def main(csvFileName=None):
 
     parser = get_argparse()
     args = parser.parse_args()
 
-    csvFileName=args.csv_file
+    csvFileName = args.csv_file
     (csvPath, csvFileNameOnly) = os.path.split(csvFileName)
     print(csvPath, csvFileNameOnly)
-    if not csvFileName.endswith('.csv'):
+    if not csvFileName.endswith(".csv"):
         print("Filename %s MUST be CSV and end in .csv (aborting)" % csvFileName)
         sys.exit(1)
 
     if not os.path.exists(args.dest_dir):
-        printf("Destination dir %s must exist a priori. Please create now." % args.dest_dir)
+        printf(
+            "Destination dir %s must exist a priori. Please create now." % args.dest_dir
+        )
         sys.exit(1)
 
     (courses, semester, created) = parseCSV(csvFileName)
     fixLabs(courses)
-    season = semester.split()[0].lower() # like Spring 2019 -> spring
-    textbookFile = semester.replace(' ', '') + '.txt'
+    season = semester.split()[0].lower()  # like Spring 2019 -> spring
+    textbookFile = semester.replace(" ", "") + ".txt"
     textbookPath = os.path.join(csvPath, textbookFile)
-    with open(textbookPath) as inf: # Spring 2019 -> Spring2019.txt
+    with open(textbookPath) as inf:  # Spring 2019 -> Spring2019.txt
         semesterData = inf.readlines()
-    textURL = semesterData[0].strip() # comment on omission of texts, or URL
+    textURL = semesterData[0].strip()  # comment on omission of texts, or URL
     # more data later?
 
-    for mainCampus in [''] + campuses:
+    for mainCampus in [""] + campuses:
         rst = toAllRST(courses, semester, created, mainCampus, textURL)
-        fName = campSeasonToDocName(mainCampus, season) + '.rst'
+        fName = campSeasonToDocName(mainCampus, season) + ".rst"
         fName = os.path.join(args.dest_dir, fName)
-        with open(fName, 'w') as outf:
+        with open(fName, "w") as outf:
             outf.write(rst)
-        print('Wrote ' + fName)
+        print("Wrote " + fName)
     printLog()
+
 
 ############ just debugging ####################
 def printLines(lines, n):  # for debugging
-    'front n > 0; end, backwards, n <0'
-    if n >0:
+    "front n > 0; end, backwards, n <0"
+    if n > 0:
         n = min(n, len(lines))
-        print('\nprinting', n, 'lines:')
+        print("\nprinting", n, "lines:")
         for line in lines[:n]:
             print(line)
     else:
         n = min(-n, len(lines))
-        print('\nprinting', n, 'lines from end back:')
-        for line in lines[-1:-n-1:-1]:
+        print("\nprinting", n, "lines from end back:")
+        for line in lines[-1 : -n - 1 : -1]:
             print(line)
+
 
 f = None
 if sys.argv[1:]:

--- a/scripts/csv2sched_spring.py
+++ b/scripts/csv2sched_spring.py
@@ -1,5 +1,5 @@
-'''script to take csv file from Locus class cedule and make
-nice .rst file <semester>.rst'''
+"""script to take csv file from LOCUS class cedule and make
+nice .rst file <semester>.rst"""
 
 from csv import reader
 
@@ -27,41 +27,45 @@ from csv import reader
 
 logList = []
 
+
 def log(s):
     logList.append(s)
 
+
 def printLog():
     if logList:
-        print('\n\nLogged items: ')
+        print("\n\nLogged items: ")
         for s in logList:
             print(s)
 
+
 def joinIndented(lines, indent):
-    'lines is a list of lines.  Return lines indented in one string'
-    if not lines:  return ''
+    "lines is a list of lines.  Return lines indented in one string"
+    if not lines:
+        return ""
     lines = [indent + line.strip() for line in lines]
-    return '\n'.join(lines)
+    return "\n".join(lines)
 
 
-sectionTemplate = '''
+sectionTemplate = """
 :doc:`{docName}`{topic} {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
     | Instructor: {instructor}
 {placeTimes}
 
 {notes}
-''' # docName link should give full course title
+"""  # docName link should give full course title
 
-comp314_315Template = '''
+comp314_315Template = """
 {area} {number} {term} (Description: :doc:`comp314-315`)
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
     | Instructor: {instructor}
 {placeTimes}
 
 {notes}
-'''
+"""
 
-topicsSectionTemplate = '''
+topicsSectionTemplate = """
 
 {area} {number} Topic{topic} {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
@@ -70,9 +74,9 @@ topicsSectionTemplate = '''
     | Description similar to: :doc:`{docName}`
 
 {notes}
-'''
+"""
 
-topicsSection367Template = '''
+topicsSection367Template = """
 
 {area} {number} Topic{topic} {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
@@ -81,8 +85,8 @@ topicsSection367Template = '''
     | Old Syllabus: `<http://people.cs.luc.edu/whonig/comp-388-488-robotics/Comp388488ROBOTICSyllabus.pdf>`_.
 
 {notes}
-'''
-topicsSection472Template = '''
+"""
+topicsSection472Template = """
 
 :doc:`comp488`: Organizational Change and Development {term}
     | Section {section} ({regCode}) Credits: {credits}; {mixture}; {format}
@@ -90,40 +94,42 @@ topicsSection472Template = '''
 {placeTimes}
 
 {notes}
-'''
+"""
+
 
 class Section:
-    '''Has members (example in paren)
-      campus (Online, Lakshore, Watertower, Cuneo)
-      term  (regular is '', 8 Week 1)
-      instructor (Willaim Honig)
-      instructorList(['Honig, William'])
-      area (COMP)
-      number (170)
-      section (002 or 02L)
-      regCode (4235)
-      title (Introduction to Computing) not used, but check?
-      format (Lecture or Laboratory)
-      credits (3 or 1-6)
-      topic (Foundations of Computer Science I - for 388, 488)
-      mixture (In person, Hybrid, Online)
-      placeTimes (indented string lines from list of place-days-time-campus)
-      notes (indented string of lines)
-      crsAbbr (comp150)
-      abbr (comp150-001)
-      docName (comp150 or special for topics course section))
-    '''
-    def __init__(self, campus, term, lines, indent = ' '*4):
+    """Has members (example in paren)
+    campus (Online, Lakshore, Watertower, Cuneo)
+    term  (regular is '', 8 Week 1)
+    instructor (Willaim Honig)
+    instructorList(['Honig, William'])
+    area (COMP)
+    number (170)
+    section (002 or 02L)
+    regCode (4235)
+    title (Introduction to Computing) not used, but check?
+    format (Lecture or Laboratory)
+    credits (3 or 1-6)
+    topic (Foundations of Computer Science I - for 388, 488)
+    mixture (In person, Hybrid, Online)
+    placeTimes (indented string lines from list of place-days-time-campus)
+    notes (indented string of lines)
+    crsAbbr (comp150)
+    abbr (comp150-001)
+    docName (comp150 or special for topics course section))
+    """
+
+    def __init__(self, campus, term, lines, indent=" " * 4):
         self.campus = campus
         self.term = term
-        if lines[2][-1].strip() != 'Instructor:': # may be no field for instructor
+        if lines[2][-1].strip() != "Instructor:":  # may be no field for instructor
             firstInstructor = lines[2][-1]
         else:
-            firstInstructor = 'Staff'
+            firstInstructor = "Staff"
         self.instructorList = [firstInstructor]
         self.area = lines[0][0].strip()
-        if self.area != 'COMP':
-            log('bad line 0:', line[0])
+        if self.area != "COMP":
+            log("bad line 0:", line[0])
         self.number = lines[0][1].strip()
         self.section = lines[0][2].strip()
         self.regCode = lines[0][3].strip()
@@ -131,87 +137,105 @@ class Section:
         self.format = lines[0][5].strip()
         self.credits = lines[0][6].strip()
         self.topic = lines[0][7].strip()
-        if self.topic:  self.topic = ': ' + self.topic
+        if self.topic:
+            self.topic = ": " + self.topic
         self.mixture = lines[1][-1].strip()[1:-1]
         self.crsAbbr = self.area.lower() + self.number
-        self.abbr = self.crsAbbr + '-' + self.section
+        self.abbr = self.crsAbbr + "-" + self.section
         self.setDocName()
-        placeTimeList = [] #allow multiple lines
+        placeTimeList = []  # allow multiple lines
         placeTimeListUnique = []
         i = 2
-        lastFriLoc = ''
-        while lines[i] and lines[i][0] == 'Bldg:':
+        lastFriLoc = ""
+        while lines[i] and lines[i][0] == "Bldg:":
             loc = getPlaceTime(lines[i], campus)
             if loc in placeTimeListUnique:
-                print('')
+                print("")
             else:
-                if ', Friday' not in loc and 'Friday' in loc:
-                    print('')
+                if ", Friday" not in loc and "Friday" in loc:
+                    print("")
                 else:
                     placeTimeListUnique.append(loc)
                     placeTimeList.append(loc)
             # assume short term Fridays as later entrues are special, not all term.
-            if i>2 and self.term and ', Friday' not in loc and 'Friday' in loc:
+            if i > 2 and self.term and ", Friday" not in loc and "Friday" in loc:
                 if lastFriLoc != loc:
-                    placeTimeList.append(loc + ' - Check week(s)')
+                    placeTimeList.append(loc + " - Check week(s)")
                 lastFriLoc = loc
 
             else:
-                if len(placeTimeListUnique)>0:
-                    print('')
+                if len(placeTimeListUnique) > 0:
+                    print("")
                 else:
                     placeTimeList.append(loc)
 
             i += 1
-            if len(lines[i-1]) == len(lines[i]) and not lines[i][0]: # further instr under orig, empty fields before
+            if (
+                len(lines[i - 1]) == len(lines[i]) and not lines[i][0]
+            ):  # further instr under orig, empty fields before
                 if lines[i][-1] and lines[i][-1] not in self.instructorList:
-                     self.instructorList.append(lines[i][-1])
+                    self.instructorList.append(lines[i][-1])
                 i += 1
 
-        lastFriLoc = ''
-        self.placeTimes = joinIndented(placeTimeList, indent + '| ')  # force separate lines
+        lastFriLoc = ""
+        self.placeTimes = joinIndented(
+            placeTimeList, indent + "| "
+        )  # force separate lines
         self.instructorList.sort()
-        self.instructor = ', '.join([parse_instructor(instr) for instr in self.instructorList])
-        if lines[i] and lines[i][0] == 'Class Enrl Cap:': #look for more unused line types in future
+        self.instructor = ", ".join(
+            [parse_instructor(instr) for instr in self.instructorList]
+        )
+        if (
+            lines[i] and lines[i][0] == "Class Enrl Cap:"
+        ):  # look for more unused line types in future
             i += 1
-        if lines[i] and lines[i][0] == 'Class Equivalents:' or lines[i][0] == 'Attributes:':
+        if (
+            lines[i]
+            and lines[i][0] == "Class Equivalents:"
+            or lines[i][0] == "Attributes:"
+        ):
             i += 1
-        if lines[i] and lines[i][0] == 'Room Characteristics:' or lines[i][0] == 'Class Equivalents:':
+        if (
+            lines[i]
+            and lines[i][0] == "Room Characteristics:"
+            or lines[i][0] == "Class Equivalents:"
+        ):
             i += 1
-        if lines[i] and lines[i][0]: # skip seq of empty column
+        if lines[i] and lines[i][0]:  # skip seq of empty column
             i += 1
-        notes = [line[0] if line else '' for line in lines[i:-1] ] # skip dashes line at end
+        notes = [
+            line[0] if line else "" for line in lines[i:-1]
+        ]  # skip dashes line at end
 
         if notes:
-            notes[0] = '**Notes:** ' + notes[0].strip()
+            notes[0] = "**Notes:** " + notes[0].strip()
         self.notes = joinIndented(notes, indent).rstrip()
 
     def setDocName(self):
-        #assume convention for section > 100, section is corresponding linked course
-        specialSect = {'502': '305'
-                      }
+        # assume convention for section > 100, section is corresponding linked course
+        specialSect = {"502": "305"}
         self.docName = self.crsAbbr
-        if self.crsAbbr in ['comp388', 'comp488']:
+        if self.crsAbbr in ["comp388", "comp488"]:
             if specialSect.get(self.section):
-                self.docName = 'comp' + specialSect[self.section]
-            elif self.section in ['301', '302']:
-                self.docName = 'comp300'
-            elif self.section =='402':
-                self.docName = 'comp488'
-            elif self.section >= '100':
-                self.docName = 'comp' + self.section
-            elif self.section >= '100':
-                self.docName = 'comp' + self.section
+                self.docName = "comp" + specialSect[self.section]
+            elif self.section in ["301", "302"]:
+                self.docName = "comp300"
+            elif self.section == "402":
+                self.docName = "comp488"
+            elif self.section >= "100":
+                self.docName = "comp" + self.section
+            elif self.section >= "100":
+                self.docName = "comp" + self.section
 
     def toRST(self):
-        if self.crsAbbr in ['comp314', 'comp315']:
+        if self.crsAbbr in ["comp314", "comp315"]:
             return comp314_315Template.format(**self.__dict__)
-        if self.crsAbbr in ['comp388', 'comp488']:
-            if self.section in ['301', '302', '402']:
+        if self.crsAbbr in ["comp388", "comp488"]:
+            if self.section in ["301", "302", "402"]:
                 return topicsSectionTemplate.format(**self.__dict__)
-            elif self.section == '367':
+            elif self.section == "367":
                 return topicsSection367Template.format(**self.__dict__)
-            elif self.section == '472':
+            elif self.section == "472":
                 return topicsSection472Template.format(**self.__dict__)
         if self.crsAbbr == self.docName:
             return sectionTemplate.format(**self.__dict__)
@@ -222,51 +246,59 @@ class Section:
 
 
 def getPlaceTime(line, campus):
-    'Return string for place, time, campus; online, TBA treated specially'
+    "Return string for place, time, campus; online, TBA treated specially"
     bldg = line[1].strip()
     room = line[3].strip()
     days = parse_days(line[5])
     clock = line[7].strip()
-    if clock == 'TBA':
-        time = 'Times: TBA'
+    if clock == "TBA":
+        time = "Times: TBA"
     else:
-        time = days + ' ' + clock
-    if campus == 'Online':
-        return 'Online ' + time
-    if room == 'TBA':
-        place = 'Place TBA'
+        time = days + " " + clock
+    if campus == "Online":
+        return "Online " + time
+    if room == "TBA":
+        place = "Place TBA"
     else:
-        place = bldg+ ':' + room
-    return '{} ({}) {}'.format(place, campus, time)
+        place = bldg + ":" + room
+    return "{} ({}) {}".format(place, campus, time)
+
 
 def parse_days(days):
-    'Remove day abbreviations: MWF -> Monday, Wednesday, Friday'
+    "Remove day abbreviations: MWF -> Monday, Wednesday, Friday"
     days = days.strip()
-    if days in ['See Note', 'TBA']:
-       return days
+    if days in ["See Note", "TBA"]:
+        return days
     orig = days
     full = []
-    for (abbr, day) in [('M', 'Monday'), ('Tu', 'Tuesday'), ('W', 'Wednesday'),
-                            ('Th', 'Thursday'), ('F', 'Friday'), ('Sa', 'Saturday')]:
+    for (abbr, day) in [
+        ("M", "Monday"),
+        ("Tu", "Tuesday"),
+        ("W", "Wednesday"),
+        ("Th", "Thursday"),
+        ("F", "Friday"),
+        ("Sa", "Saturday"),
+    ]:
         if abbr in days:
             full.append(day)
-            days = days.replace(abbr, '')
+            days = days.replace(abbr, "")
     if days or not orig:
-        log('Bad days code ' + orig)
-        return 'TBA'
-    return ', '.join(full)
+        log("Bad days code " + orig)
+        return "TBA"
+    return ", ".join(full)
+
 
 # decodes the instructor names putting them in order: "Smith,Adam" = Adam Smith
 def parse_instructor(instructor):
-    parts = instructor.split(',')
-    if '' in parts:
-        return 'TBA'
+    parts = instructor.split(",")
+    if "" in parts:
+        return "TBA"
     else:
         parts.reverse()
-        return ' '.join(parts)
+        return " ".join(parts)
 
 
-headingTemplate = '''
+headingTemplate = """
 {semester} Schedule {textURLline}
 ==========================================================================
 {created}
@@ -283,9 +315,9 @@ For open/full status and latest changes, see
 Section titles lines link to the course description page,
 except for some labeled special topics courses related to an existing course.
 
-The 4-digit number in parentheses after the section is the Locus registration code.
+The 4-digit number in parentheses after the section is the LOCUS registration code.
 
-Be sure to look at the section's notes or Locus for an 8-week courses with more than one schedule line:
+Be sure to look at the section's notes or LOCUS for an 8-week courses with more than one schedule line:
 Friday line(s) are likely to be isolated makeup days, not every week.
 
 {graduateLink}
@@ -300,55 +332,58 @@ Friday line(s) are likely to be isolated makeup days, not every week.
 {udergradeTxt}
 ~~~~~~~~~~~~~~~~~~~~~
 
-'''
+"""
 
-gradHeadingTemplate = '''
+gradHeadingTemplate = """
 
 .. _{season}_graduate_courses_list_{mainCampus}:
 
 Graduate Courses
 ~~~~~~~~~~~~~~~~~~~~~
 
-'''
+"""
 
-indepStudyTemplate = '''
+indepStudyTemplate = """
 :doc:`{}` 1-6 credits
     You cannot register
     yourself for an independent study course!
     You must find a faculty member who
     agrees to supervisor the work that you outline and schedule together.  This
     *supervisor arranges to get you registered*.  Possible supervisors are: {}
-'''
+"""
+
 
 def doIndepStudyRST(crsAbbr, courses):
     names = []
     for section in courses:
         if courses[section].crsAbbr == crsAbbr:
-           names += courses[section].instructorList
-    names = [name for name in names if name != 'Staff']
+            names += courses[section].instructorList
+    names = [name for name in names if name != "Staff"]
     names.sort()  # name last-first for sorting
     names = [parse_instructor(name) for name in names]
     if len(names) == 0:
-        if(crsAbbr == 'comp490'):
+        if crsAbbr == "comp490":
             names = "Mark Albert, Dmitriy Dligach, Peter L Dordal, Ronald I Greenberg, Nicholas J Hayward, William Honig, Konstantin Laufer, Channah Naiman, Catherine Putonti, Chandra N Sekharan, George Thiruvathukal, Heather E. Wheeler, Robert Yacobellis"
-        if(crsAbbr == 'comp398'):
+        if crsAbbr == "comp398":
             names = "Dmitriy Dligach, Peter L Dordal, Ronald I Greenberg, Nicholas J Hayward, William Honig, Konstantin Laufer, Channah Naiman, Maria Del Carmen Saenz, Chandra N Sekharan, George Thiruvathukal, Heather E. Wheeler, Robert Yacobellis"
         return indepStudyTemplate.format(crsAbbr, names)
-    return indepStudyTemplate.format(crsAbbr, ', '.join(names))
+    return indepStudyTemplate.format(crsAbbr, ", ".join(names))
+
 
 def fixLabs(courses):
     for name, sect in list(courses.items()):
-        if sect.section.endswith('L'):
-            mainAbbr = name.replace('-', '-0')[:-1] # comp170-02L -> comp170-002
+        if sect.section.endswith("L"):
+            mainAbbr = name.replace("-", "-0")[:-1]  # comp170-02L -> comp170-002
             mainSect = courses.get(mainAbbr)
             if mainSect:
-                mainSect.format += '/Lab'
-                mainSect.placeTimes += '\n' + sect.placeTimes + ' (lab)'
-                mainSect.section += '/' + sect.section
-                del(courses[name])
+                mainSect.format += "/Lab"
+                mainSect.placeTimes += "\n" + sect.placeTimes + " (lab)"
+                mainSect.section += "/" + sect.section
+                del courses[name]
+
 
 def doLevelRST(names, indep, rstParts, courses):
-    'Assemble grad or undergrad part with special independent study entry'
+    "Assemble grad or undergrad part with special independent study entry"
     for sect in names:
         if sect == indep:
             rstParts.append(doIndepStudyRST(sect, courses))
@@ -356,263 +391,298 @@ def doLevelRST(names, indep, rstParts, courses):
         if course:  # so not deleted lab section
             rstParts.append(course.toRST())
 
-def toRST(courses, semester, created, mainCampus, textURL=''):
-    'return the entire rst file contents'
-    undergrad = ['comp398'] + [section for section in courses   # one placeholder for 398
-                               if courses[section].area == 'COMP' and
-                                  '398' != courses[section].number < '400']
+
+def toRST(courses, semester, created, mainCampus, textURL=""):
+    "return the entire rst file contents"
+    undergrad = ["comp398"] + [
+        section
+        for section in courses  # one placeholder for 398
+        if courses[section].area == "COMP" and "398" != courses[section].number < "400"
+    ]
     undergrad.sort()
 
-    fixLabs(courses) # need if stupid separate lab sections
-    grad = ['comp490'] + [section for section in courses  # one placeholder for 490
-                          if courses[section].area == 'COMP' and
-                             '490' != courses[section].number >= '400']
+    fixLabs(courses)  # need if stupid separate lab sections
+    grad = ["comp490"] + [
+        section
+        for section in courses  # one placeholder for 490
+        if courses[section].area == "COMP" and "490" != courses[section].number >= "400"
+    ]
     grad.sort()
 
     # later CSIS, too?
 
     season = semester.split()[0]
-    txtBookURLTemplate= '''See `Textbook Information <{textURL}>`_.'''
-    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ''
-    textURLTemplate= '''( `{mainCampus}` Campus )'''
-    textURLline = textURLTemplate.format(**locals()) if mainCampus else ''
-    campusURLTemplate= '''
+    txtBookURLTemplate = """See `Textbook Information <{textURL}>`_."""
+    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ""
+    textURLTemplate = """( `{mainCampus}` Campus )"""
+    textURLline = textURLTemplate.format(**locals()) if mainCampus else ""
+    campusURLTemplate = """
 :doc:`lakeShoreSpring`
 
 :doc:`waterTowerSpring`
 
 :doc:`cuneoSpring`
 
-:doc:`onlineSpring` '''
-    campusURLTemplateCuneo= '''
+:doc:`onlineSpring` """
+    campusURLTemplateCuneo = """
 :doc:`lakeShoreSpring`
 
 :doc:`waterTowerSpring`
 
-:doc:`onlineSpring` '''
-    graduateLink = '''
+:doc:`onlineSpring` """
+    graduateLink = """
 You can skip down to
-:ref:`Spring_graduate_courses_list_`. '''
-    udergradeTxt = 'Undergraduate Courses'
+:ref:`Spring_graduate_courses_list_`. """
+    udergradeTxt = "Undergraduate Courses"
     parts = [headingTemplate.format(**locals())]
 
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    doLevelRST(undergrad, "comp398", parts, courses)
     parts.append(gradHeadingTemplate.format(**locals()))
-    doLevelRST(grad, 'comp490', parts, courses)
+    doLevelRST(grad, "comp490", parts, courses)
 
-    return '\n'.join(parts)
+    return "\n".join(parts)
 
 
-
-def toLSRST(courses, semester, created, mainCampus, textURL=''):
-    'return the entire rst file contents'
-    undergrad = ['comp398'] + [section for section in courses   # one placeholder for 398
-                               if courses[section].area == 'COMP' and
-                                  '398' != courses[section].number < '400' and
-                                  courses[section].campus == 'Lake Shore']
+def toLSRST(courses, semester, created, mainCampus, textURL=""):
+    "return the entire rst file contents"
+    undergrad = ["comp398"] + [
+        section
+        for section in courses  # one placeholder for 398
+        if courses[section].area == "COMP"
+        and "398" != courses[section].number < "400"
+        and courses[section].campus == "Lake Shore"
+    ]
     undergrad.sort()
 
-    fixLabs(courses) # need if stupid separate lab sections
-    grad = ['comp490'] + [section for section in courses  # one placeholder for 490
-                          if courses[section].area == 'COMP' and
-                             '490' != courses[section].number >= '400' and
-                                  courses[section].campus == 'Lake Shore']
+    fixLabs(courses)  # need if stupid separate lab sections
+    grad = ["comp490"] + [
+        section
+        for section in courses  # one placeholder for 490
+        if courses[section].area == "COMP"
+        and "490" != courses[section].number >= "400"
+        and courses[section].campus == "Lake Shore"
+    ]
     grad.sort()
 
     # later CSIS, too?
-    mainCampus = 'Lake Shore'
+    mainCampus = "Lake Shore"
     season = semester.split()[0]
-    txtBookURLTemplate= '''See `Textbook Information <{textURL}>`_.'''
-    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ''
-    textURLTemplate= '''( {mainCampus} Campus )'''
-    textURLline = textURLTemplate.format(**locals()) if mainCampus else ''
-    campusURLTemplate= '''
+    txtBookURLTemplate = """See `Textbook Information <{textURL}>`_."""
+    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ""
+    textURLTemplate = """( {mainCampus} Campus )"""
+    textURLline = textURLTemplate.format(**locals()) if mainCampus else ""
+    campusURLTemplate = """
 :doc:`spring`
 
 :doc:`waterTowerSpring`
 
 :doc:`cuneoSpring`
 
-:doc:`onlineSpring` '''
-    campusURLTemplateCuneo= '''
+:doc:`onlineSpring` """
+    campusURLTemplateCuneo = """
 :doc:`spring`
 
 :doc:`waterTowerSpring`
 
-:doc:`onlineSpring` '''
-    graduateLink = '''
+:doc:`onlineSpring` """
+    graduateLink = """
 You can skip down to
-:ref:`Spring_graduate_courses_list_Lake Shore`. '''
-    udergradeTxt = 'Undergraduate Courses'
+:ref:`Spring_graduate_courses_list_Lake Shore`. """
+    udergradeTxt = "Undergraduate Courses"
     parts = [headingTemplate.format(**locals())]
 
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    doLevelRST(undergrad, "comp398", parts, courses)
     parts.append(gradHeadingTemplate.format(**locals()))
-    doLevelRST(grad, 'comp490', parts, courses)
-    return '\n'.join(parts)
+    doLevelRST(grad, "comp490", parts, courses)
+    return "\n".join(parts)
 
-def toWTRST(courses, semester, created, mainCampus, textURL=''):
-    'return the entire rst file contents'
-    undergrad = ['comp398'] + [section for section in courses   # one placeholder for 398
-                               if courses[section].area == 'COMP' and
-                                  '398' != courses[section].number < '400' and
-                                  courses[section].campus == 'Water Tower']
+
+def toWTRST(courses, semester, created, mainCampus, textURL=""):
+    "return the entire rst file contents"
+    undergrad = ["comp398"] + [
+        section
+        for section in courses  # one placeholder for 398
+        if courses[section].area == "COMP"
+        and "398" != courses[section].number < "400"
+        and courses[section].campus == "Water Tower"
+    ]
     undergrad.sort()
 
-    fixLabs(courses) # need if stupid separate lab sections
-    grad = ['comp490'] + [section for section in courses  # one placeholder for 490
-                          if courses[section].area == 'COMP' and
-                             '490' != courses[section].number >= '400' and
-                                  courses[section].campus == 'Water Tower']
+    fixLabs(courses)  # need if stupid separate lab sections
+    grad = ["comp490"] + [
+        section
+        for section in courses  # one placeholder for 490
+        if courses[section].area == "COMP"
+        and "490" != courses[section].number >= "400"
+        and courses[section].campus == "Water Tower"
+    ]
     grad.sort()
 
     # later CSIS, too?
-    mainCampus = 'Water Tower'
+    mainCampus = "Water Tower"
     season = semester.split()[0]
-    txtBookURLTemplate= '''See `Textbook Information <{textURL}>`_.'''
-    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ''
-    textURLTemplate= '''( {mainCampus} Campus )'''
-    textURLline = textURLTemplate.format(**locals()) if mainCampus else ''
-    campusURLTemplate= '''
+    txtBookURLTemplate = """See `Textbook Information <{textURL}>`_."""
+    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ""
+    textURLTemplate = """( {mainCampus} Campus )"""
+    textURLline = textURLTemplate.format(**locals()) if mainCampus else ""
+    campusURLTemplate = """
 :doc:`spring`
 
 :doc:`lakeShoreSpring`
 
 :doc:`cuneoSpring`
 
-:doc:`onlineSpring` '''
-    campusURLTemplateCuneo= '''
+:doc:`onlineSpring` """
+    campusURLTemplateCuneo = """
 :doc:`spring`
 
 :doc:`lakeShoreSpring`
 
-:doc:`onlineSpring` '''
-    graduateLink = '''
+:doc:`onlineSpring` """
+    graduateLink = """
 You can skip down to
-:ref:`Spring_graduate_courses_list_Water Tower`. '''
-    udergradeTxt = 'Undergraduate Courses'
+:ref:`Spring_graduate_courses_list_Water Tower`. """
+    udergradeTxt = "Undergraduate Courses"
     parts = [headingTemplate.format(**locals())]
 
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    doLevelRST(undergrad, "comp398", parts, courses)
     parts.append(gradHeadingTemplate.format(**locals()))
-    doLevelRST(grad, 'comp490', parts, courses)
+    doLevelRST(grad, "comp490", parts, courses)
 
-    return '\n'.join(parts)
+    return "\n".join(parts)
 
-def toCuneoRST(courses, semester, created, mainCampus, textURL=''):
-    'return the entire rst file contents'
-    undergrad = [section for section in courses   # one placeholder for 398
-                               if courses[section].area == 'COMP' and
-                                  '398' != courses[section].number < '400' and
-                                  courses[section].campus == 'Cuneo Mansion']
+
+def toCuneoRST(courses, semester, created, mainCampus, textURL=""):
+    "return the entire rst file contents"
+    undergrad = [
+        section
+        for section in courses  # one placeholder for 398
+        if courses[section].area == "COMP"
+        and "398" != courses[section].number < "400"
+        and courses[section].campus == "Cuneo Mansion"
+    ]
     undergrad.sort()
 
-    fixLabs(courses) # need if stupid separate lab sections
-    grad = ['comp490'] + [section for section in courses  # one placeholder for 490
-                          if courses[section].area == 'COMP' and
-                             '490' != courses[section].number >= '400' and
-                                  courses[section].campus == 'Cuneo Mansion']
+    fixLabs(courses)  # need if stupid separate lab sections
+    grad = ["comp490"] + [
+        section
+        for section in courses  # one placeholder for 490
+        if courses[section].area == "COMP"
+        and "490" != courses[section].number >= "400"
+        and courses[section].campus == "Cuneo Mansion"
+    ]
     grad.sort()
 
     # later CSIS, too?
-    mainCampus = 'Cuneo Mansion'
+    mainCampus = "Cuneo Mansion"
     season = semester.split()[0]
-    txtBookURLTemplate= '''See `Textbook Information <{textURL}>`_.'''
-    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ''
-    textURLTemplate= '''( {mainCampus} Campus )'''
-    textURLline = textURLTemplate.format(**locals()) if mainCampus else ''
-    campusURLTemplate= '''
+    txtBookURLTemplate = """See `Textbook Information <{textURL}>`_."""
+    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ""
+    textURLTemplate = """( {mainCampus} Campus )"""
+    textURLline = textURLTemplate.format(**locals()) if mainCampus else ""
+    campusURLTemplate = """
 :doc:`spring`
 
 :doc:`lakeShoreSpring`
 
 :doc:`waterTowerSpring`
 
-:doc:`onlineSpring` '''
-    campusURLTemplateCuneo = ''
-    graduateLink = ''
-    udergradeTxt = ''
+:doc:`onlineSpring` """
+    campusURLTemplateCuneo = ""
+    graduateLink = ""
+    udergradeTxt = ""
     parts = [headingTemplate.format(**locals())]
 
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    doLevelRST(undergrad, "comp398", parts, courses)
     parts.append(gradHeadingTemplate.format(**locals()))
-    doLevelRST(grad, 'comp490', parts, courses)
+    doLevelRST(grad, "comp490", parts, courses)
 
-    return '\n'.join(parts)
+    return "\n".join(parts)
 
-def toOnlineRST(courses, semester, created, mainCampus, textURL=''):
-    'return the entire rst file contents'
-    undergrad = ['comp398'] + [section for section in courses   # one placeholder for 398
-                               if courses[section].area == 'COMP' and
-                                  '398' != courses[section].number < '400' and
-                                  courses[section].campus == 'Online']
+
+def toOnlineRST(courses, semester, created, mainCampus, textURL=""):
+    "return the entire rst file contents"
+    undergrad = ["comp398"] + [
+        section
+        for section in courses  # one placeholder for 398
+        if courses[section].area == "COMP"
+        and "398" != courses[section].number < "400"
+        and courses[section].campus == "Online"
+    ]
     undergrad.sort()
 
-    fixLabs(courses) # need if stupid separate lab sections
-    grad = ['comp490'] + [section for section in courses  # one placeholder for 490
-                          if courses[section].area == 'COMP' and
-                             '490' != courses[section].number >= '400' and
-                                  courses[section].campus == 'Online']
+    fixLabs(courses)  # need if stupid separate lab sections
+    grad = ["comp490"] + [
+        section
+        for section in courses  # one placeholder for 490
+        if courses[section].area == "COMP"
+        and "490" != courses[section].number >= "400"
+        and courses[section].campus == "Online"
+    ]
     grad.sort()
 
     # later CSIS, too?
-    mainCampus = 'Online'
+    mainCampus = "Online"
     season = semester.split()[0]
-    txtBookURLTemplate= '''See `Textbook Information <{textURL}>`_.'''
-    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ''
-    textURLTemplate= '''( {mainCampus} Courses )'''
-    textURLline = textURLTemplate.format(**locals()) if mainCampus else ''
-    campusURLTemplate= '''
+    txtBookURLTemplate = """See `Textbook Information <{textURL}>`_."""
+    txtBookURLline = txtBookURLTemplate.format(**locals()) if textURL else ""
+    textURLTemplate = """( {mainCampus} Courses )"""
+    textURLline = textURLTemplate.format(**locals()) if mainCampus else ""
+    campusURLTemplate = """
 :doc:`spring`
 
 :doc:`lakeShoreSpring`
 
 :doc:`waterTowerSpring`
 
-:doc:`cuneoSpring` '''
-    campusURLTemplateCuneo= '''
+:doc:`cuneoSpring` """
+    campusURLTemplateCuneo = """
 :doc:`spring`
 
 :doc:`lakeShoreSpring`
 
-:doc:`waterTowerSpring` '''
-    graduateLink = '''
+:doc:`waterTowerSpring` """
+    graduateLink = """
 You can skip down to
-:ref:`spring_graduate_courses_list_Online`. '''
-    udergradeTxt = 'Undergraduate Courses'
+:ref:`spring_graduate_courses_list_Online`. """
+    udergradeTxt = "Undergraduate Courses"
     parts = [headingTemplate.format(**locals())]
 
-    doLevelRST(undergrad, 'comp398', parts, courses)
+    doLevelRST(undergrad, "comp398", parts, courses)
     parts.append(gradHeadingTemplate.format(**locals()))
-    doLevelRST(grad, 'comp490', parts, courses)
+    doLevelRST(grad, "comp490", parts, courses)
 
-    return '\n'.join(parts)
+    return "\n".join(parts)
+
+
 def printLines(lines, n):
-    'front n > 0; end, backwards, n <0'
-    if n >0:
+    "front n > 0; end, backwards, n <0"
+    if n > 0:
         n = min(n, len(lines))
-        print('\nprinting', n, 'lines:')
+        print("\nprinting", n, "lines:")
         for line in lines[:n]:
             print(line)
     else:
         n = min(-n, len(lines))
-        print('\nprinting', n, 'lines from end back:')
-        for line in lines[-1:-n-1:-1]:
+        print("\nprinting", n, "lines from end back:")
+        for line in lines[-1 : -n - 1 : -1]:
             print(line)
 
+
 def getLines(rawLines):
-    '''return csv list of entries for each line,
-    If rawLines is a string it is taken as a csv file name'''
+    """return csv list of entries for each line,
+    If rawLines is a string it is taken as a csv file name"""
     if isinstance(rawLines, str):
         with open(rawLines) as inf:
             lines = list(reader(inf))
-        #printLines(lines, 15)
+        # printLines(lines, 15)
         return lines
     return list(reader(rawLines))
 
 
 def isDashes(s):
-    return s.startswith('_____________')
+    return s.startswith("_____________")
+
 
 def getToDashes(lines):
     part = []
@@ -625,77 +695,117 @@ def getToDashes(lines):
 
 
 def parseCSV(csvFile):
-    '''return dictionary of courses, semester heading data'''
-    #ToDo: check fits assumed format
+    """return dictionary of courses, semester heading data"""
+    # ToDo: check fits assumed format
     lines = getLines(csvFile)
     lines.reverse()
-    #printLines(lines, -15) #DEBUG
+    # printLines(lines, -15) #DEBUG
     courses = {}
-    campus = 'Not set'
-    term = 'Not set'
-    semester = 'Not set'
-    created = 'Not set'
-    mainCampus = ''
+    campus = "Not set"
+    term = "Not set"
+    semester = "Not set"
+    created = "Not set"
+    mainCampus = ""
 
-    while(lines):
+    while lines:
         part = getToDashes(lines)
         if part is None:
-            #print('At end!') #DEBUG
+            # print('At end!') #DEBUG
             return (courses, semester, created, mainCampus)
-        #print('Current section: ') #DEBUG
-        #for line in part: #DEBUG
+        # print('Current section: ') #DEBUG
+        # for line in part: #DEBUG
         #    print(line)
-        if part[-1][-1] == 'Topics': # page header
-            if not part[0][0]:  #empty commas at start for all but first page
+        if part[-1][-1] == "Topics":  # page header
+            if not part[0][0]:  # empty commas at start for all but first page
                 part = part[1:]
-            #print('Parsing page', part[0][3], 'semester', part[1][0]) #DEBUG
-            semester = ' '.join(part[1][0].split()[-2:]) # last two words of first entry in second line
+            # print('Parsing page', part[0][3], 'semester', part[1][0]) #DEBUG
+            semester = " ".join(
+                part[1][0].split()[-2:]
+            )  # last two words of first entry in second line
             date = part[1][2]
             time = part[2][2]
-            campus = part[2][0].partition('Location')[0].strip().replace('Campus: ', '').replace(' Campus', '')
+            campus = (
+                part[2][0]
+                .partition("Location")[0]
+                .strip()
+                .replace("Campus: ", "")
+                .replace(" Campus", "")
+            )
             # assume campus and location same?
-            term = part[3][0] # empty string for regular session
+            term = part[3][0]  # empty string for regular session
 
-            if term == 'Regular Academic Session':
-            	term = ''
+            if term == "Regular Academic Session":
+                term = ""
             if term:
-                term = '[Term: ' + term + ']'
-            created = 'Updated {} {}'.format(date, time)
-            #not in use
-            #if not term and part[3][6] != 'Regular Academic Session':
-              # term = '[Term: ' + part[3][6] + ']'
+                term = "[Term: " + term + "]"
+            created = "Updated {} {}".format(date, time)
+            # not in use
+            # if not term and part[3][6] != 'Regular Academic Session':
+            # term = '[Term: ' + part[3][6] + ']'
         else:  # section description
-            #print('Processing section') #DEBUG
+            # print('Processing section') #DEBUG
             section = Section(campus, term, part)
             courses[section.abbr] = section
-        #input('press return: ')  #DEBUG
+        # input('press return: ')  #DEBUG
+
 
 def main():
-    (courses, semester, created, mainCampus) = parseCSV('Spring2018.csv')
-    rst = toRST(courses, semester, created, mainCampus, textURL='https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing')
+    (courses, semester, created, mainCampus) = parseCSV("Spring2018.csv")
+    rst = toRST(
+        courses,
+        semester,
+        created,
+        mainCampus,
+        textURL="https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing",
+    )
     printLog()
-    with open('source/spring.rst', 'w') as outf:
+    with open("source/spring.rst", "w") as outf:
         outf.write(rst)
-##    if sys.args
-#RST file for Lake shore Campus
-    lsrst = toLSRST(courses, semester, created, mainCampus, textURL='https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing')
+    ##    if sys.args
+    # RST file for Lake shore Campus
+    lsrst = toLSRST(
+        courses,
+        semester,
+        created,
+        mainCampus,
+        textURL="https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing",
+    )
     printLog()
-    with open('source/lakeShoreSpring.rst', 'w') as outf:
+    with open("source/lakeShoreSpring.rst", "w") as outf:
         outf.write(lsrst)
-#RST file for Water Tower Campus
-    wtrst = toWTRST(courses, semester, created, mainCampus, textURL='https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing')
+    # RST file for Water Tower Campus
+    wtrst = toWTRST(
+        courses,
+        semester,
+        created,
+        mainCampus,
+        textURL="https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing",
+    )
     printLog()
-    with open('source/waterTowerSpring.rst', 'w') as outf:
+    with open("source/waterTowerSpring.rst", "w") as outf:
         outf.write(wtrst)
-#RST file for Cuneo Courses
-    cuneorst = toCuneoRST(courses, semester, created, mainCampus, textURL='https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing')
+    # RST file for Cuneo Courses
+    cuneorst = toCuneoRST(
+        courses,
+        semester,
+        created,
+        mainCampus,
+        textURL="https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing",
+    )
     printLog()
-    with open('source/cuneoSpring.rst', 'w') as outf:
+    with open("source/cuneoSpring.rst", "w") as outf:
         outf.write(cuneorst)
-#RST file for Online Courses
-    onlinerst = toOnlineRST(courses, semester, created, mainCampus, textURL='https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing')
+    # RST file for Online Courses
+    onlinerst = toOnlineRST(
+        courses,
+        semester,
+        created,
+        mainCampus,
+        textURL="https://docs.google.com/spreadsheets/d/1Xucka4tluanvfHP-pAcbzG5sVBwvoTN1DQyu9t3rxdk/edit?usp=sharing",
+    )
     printLog()
-    with open('source/onlineSpring.rst', 'w') as outf:
+    with open("source/onlineSpring.rst", "w") as outf:
         outf.write(onlinerst)
+
 
 main()

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,6 +18,10 @@ from datetime import date
 rst_epilog = (
     """
 
+.. |acct201| replace:: `ACCT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainaccounting/#692265>`_
+
+.. |mgmt201| replace:: `MGMT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainmanagement/#675009>`_
+
 .. |math100| replace:: `MATH 100: Intermediate Algebra <http://luc.edu/math/academics/courses/math100/index.shtml>`_
 
 .. |math117| replace:: `MATH 117: College Algebra <http://luc.edu/math/academics/courses/math117/index.shtml>`_
@@ -100,7 +104,11 @@ rst_epilog = (
 
 .. |phys351| replace:: `PHYS 351: Electricity & Magnetism I <http://www.luc.edu/physics/courses.shtml#351>`_
 
+.. |phys366| replace:: `PHYS 366 <https://www.luc.edu/physics/courses.shtml#366>`_
+
 .. |biol101| replace:: `BIOL 101: General Biology I <http://luc.edu/biology/bsinbiology/courseofferings/>`_
+
+.. |biol102| replace:: `BIOL 102 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`_
 
 .. |biol282| replace:: `BIOL 282: Genetics <http://luc.edu/biology/bsinbiology/courseofferings/>`_
 
@@ -125,6 +133,8 @@ rst_epilog = (
 .. |cjc323| replace:: `CJC 323: Criminal Procedure <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
 
 .. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`_. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
+
+.. |locus| replace::`Locus <https://locus.luc.edu>`_
 
 .. |see-syllabi| replace:: See the :doc:`../syllabi/syllabi`.
 """

--- a/source/conf.py
+++ b/source/conf.py
@@ -126,6 +126,7 @@ rst_epilog = (
 
 .. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`__. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
 
+.. |see-syllabi| replace:: See the :doc:`../syllabi/syllabi`.
 """
     % vars()
 )

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,113 +18,113 @@ from datetime import date
 rst_epilog = (
     """
 
-.. |math100| replace:: `MATH 100: Intermediate Algebra <http://luc.edu/math/academics/courses/math100/index.shtml>`__
+.. |math100| replace:: `MATH 100: Intermediate Algebra <http://luc.edu/math/academics/courses/math100/index.shtml>`_
 
-.. |math117| replace:: `MATH 117: College Algebra <http://luc.edu/math/academics/courses/math117/index.shtml>`__
+.. |math117| replace:: `MATH 117: College Algebra <http://luc.edu/math/academics/courses/math117/index.shtml>`_
 
-.. |math118| replace:: `MATH 118: Precalculus <http://luc.edu/math/academics/courses/math118/index.shtml>`__
+.. |math118| replace:: `MATH 118: Precalculus <http://luc.edu/math/academics/courses/math118/index.shtml>`_
 
-.. |math131| replace:: `MATH 131: Applied Calculus I <http://luc.edu/math/academics/courses/math131/index.shtml>`__
+.. |math131| replace:: `MATH 131: Applied Calculus I <http://luc.edu/math/academics/courses/math131/index.shtml>`_
 
-.. |math132| replace:: `MATH 132: Applied Calculus II <http://luc.edu/math/academics/courses/math132/index.shtml>`__
+.. |math132| replace:: `MATH 132: Applied Calculus II <http://luc.edu/math/academics/courses/math132/index.shtml>`_
 
-.. |math161| replace:: `MATH 161: Calculus I <http://luc.edu/math/academics/courses/math161/index.shtml>`__
+.. |math161| replace:: `MATH 161: Calculus I <http://luc.edu/math/academics/courses/math161/index.shtml>`_
 
-.. |math162| replace:: `MATH 162: Calculus II <http://luc.edu/math/academics/courses/math162/index.shtml>`__
+.. |math162| replace:: `MATH 162: Calculus II <http://luc.edu/math/academics/courses/math162/index.shtml>`_
 
-.. |math201| replace:: `MATH 201: Introduction to Discrete Mathematics and Number Theory <http://luc.edu/math/academics/courses/math201/index.shtml>`__
+.. |math201| replace:: `MATH 201: Introduction to Discrete Mathematics and Number Theory <http://luc.edu/math/academics/courses/math201/index.shtml>`_
 
-.. |math212| replace:: `MATH 212: Linear Algebra <http://luc.edu/math/academics/courses/math212/index.shtml>`__
+.. |math212| replace:: `MATH 212: Linear Algebra <http://luc.edu/math/academics/courses/math212/index.shtml>`_
 
-.. |math215| replace:: `MATH 215: Object Oriented Math Programming <http://luc.edu/math/academics/courses/math215/index.shtml>`__
+.. |math215| replace:: `MATH 215: Object Oriented Math Programming <http://luc.edu/math/academics/courses/math215/index.shtml>`_
 
-.. |math263| replace:: `MATH 263: Multivariable Calculus <http://luc.edu/math/academics/courses/math263/index.shtml>`__
+.. |math263| replace:: `MATH 263: Multivariable Calculus <http://luc.edu/math/academics/courses/math263/index.shtml>`_
 
-.. |math264| replace:: `MATH 264: Ordinary Differential Equations <http://luc.edu/math/academics/courses/math264/index.shtml>`__
+.. |math264| replace:: `MATH 264: Ordinary Differential Equations <http://luc.edu/math/academics/courses/math264/index.shtml>`_
 
-.. |math304| replace:: `MATH 304: Probability and Statistics I <http://luc.edu/math/academics/courses/math304/index.shtml>`__
+.. |math304| replace:: `MATH 304: Probability and Statistics I <http://luc.edu/math/academics/courses/math304/index.shtml>`_
 
-.. |math309| replace:: `MATH 309: Numerical Methods <http://luc.edu/math/academics/courses/math309/index.shtml>`__
+.. |math309| replace:: `MATH 309: Numerical Methods <http://luc.edu/math/academics/courses/math309/index.shtml>`_
 
-.. |math313| replace:: `MATH 313: Abstract Algebra <http://luc.edu/math/academics/courses/math313/index.shtml>`__
+.. |math313| replace:: `MATH 313: Abstract Algebra <http://luc.edu/math/academics/courses/math313/index.shtml>`_
 
-.. |math314| replace:: `MATH 314: Advanced Topics in Abstract Algebra <http://luc.edu/math/academics/courses/math314/index.shtml>`__
+.. |math314| replace:: `MATH 314: Advanced Topics in Abstract Algebra <http://luc.edu/math/academics/courses/math314/index.shtml>`_
 
-.. |math315| replace:: `MATH 315: Advanced Topics in Linear Algebra <http://luc.edu/math/academics/courses/math315/index.shtml>`__
+.. |math315| replace:: `MATH 315: Advanced Topics in Linear Algebra <http://luc.edu/math/academics/courses/math315/index.shtml>`_
 
-.. |math328| replace:: `MATH 328: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math328/index.shtml>`__
+.. |math328| replace:: `MATH 328: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math328/index.shtml>`_
 
-.. |math331| replace:: `MATH 331: Cryptography <http://luc.edu/math/academics/courses/math331/index.shtml>`__
+.. |math331| replace:: `MATH 331: Cryptography <http://luc.edu/math/academics/courses/math331/index.shtml>`_
 
-.. |math351| replace:: `MATH 351: Introduction to Real Analysis I <http://luc.edu/math/academics/courses/math351/index.shtml>`__
+.. |math351| replace:: `MATH 351: Introduction to Real Analysis I <http://luc.edu/math/academics/courses/math351/index.shtml>`_
 
-.. |math352| replace:: `MATH 352: Introduction to Real Analysis II <http://luc.edu/math/academics/courses/math352/index.shtml>`__
+.. |math352| replace:: `MATH 352: Introduction to Real Analysis II <http://luc.edu/math/academics/courses/math352/index.shtml>`_
 
-.. |math353| replace:: `MATH 353: Introductory Complex Analysis <http://luc.edu/math/academics/courses/math353/index.shtml>`__
+.. |math353| replace:: `MATH 353: Introductory Complex Analysis <http://luc.edu/math/academics/courses/math353/index.shtml>`_
 
-.. |math409| replace:: `MATH 409: Advanced Numerical Anaylsis <http://luc.edu/math/academics/courses/math409/index.shtml>`__
+.. |math409| replace:: `MATH 409: Advanced Numerical Anaylsis <http://luc.edu/math/academics/courses/math409/index.shtml>`_
 
-.. |math428| replace:: `MATH 428: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math428/index.shtml>`__
+.. |math428| replace:: `MATH 428: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math428/index.shtml>`_
 
-.. |stat103| replace:: `STAT 103: Fundamentals of Statistics <http://www.luc.edu/math/academics/courses/stat103/>`__
+.. |stat103| replace:: `STAT 103: Fundamentals of Statistics <http://www.luc.edu/math/academics/courses/stat103/>`_
 
-.. |stat203| replace:: `STAT 203: Statistics <http://luc.edu/math/academics/courses/stat203/index.shtml>`__
+.. |stat203| replace:: `STAT 203: Statistics <http://luc.edu/math/academics/courses/stat203/index.shtml>`_
 
-.. |stat304| replace:: `STAT 304: Probability and Statistics I <http://luc.edu/math/academics/courses/stat304/index.shtml>`__
+.. |stat304| replace:: `STAT 304: Probability and Statistics I <http://luc.edu/math/academics/courses/stat304/index.shtml>`_
 
-.. |phil120| replace:: `PHIL 120 <http://luc.edu/philosophy/coursedescriptions.shtml>`__
+.. |phil120| replace:: `PHIL 120 <http://luc.edu/philosophy/coursedescriptions.shtml>`_
 
-.. |phys112| replace:: `PHYS 112: College Physics II <http://www.luc.edu/physics/courses.shtml#112>`__
+.. |phys112| replace:: `PHYS 112: College Physics II <http://www.luc.edu/physics/courses.shtml#112>`_
 
-.. |phys125| replace:: `PHYS 125: General Physics I <http://www.luc.edu/physics/courses.shtml#125>`__
+.. |phys125| replace:: `PHYS 125: General Physics I <http://www.luc.edu/physics/courses.shtml#125>`_
 
-.. |phys126| replace:: `PHYS 126: General Physics II <http://www.luc.edu/physics/courses.shtml#126>`__
+.. |phys126| replace:: `PHYS 126: General Physics II <http://www.luc.edu/physics/courses.shtml#126>`_
 
-.. |phys135| replace:: `PHYS 135: General Physics Lab I <http://www.luc.edu/physics/courses.shtml#135>`__
+.. |phys135| replace:: `PHYS 135: General Physics Lab I <http://www.luc.edu/physics/courses.shtml#135>`_
 
-.. |phys136| replace:: `PHYS 136: General Physics Lab II <http://www.luc.edu/physics/courses.shtml#136>`__
+.. |phys136| replace:: `PHYS 136: General Physics Lab II <http://www.luc.edu/physics/courses.shtml#136>`_
 
-.. |phys235| replace:: `PHYS 235: Modern Physics <http://www.luc.edu/physics/courses.shtml#235>`__
+.. |phys235| replace:: `PHYS 235: Modern Physics <http://www.luc.edu/physics/courses.shtml#235>`_
 
-.. |phys237| replace:: `PHYS 237: Modern Physics Lab <http://www.luc.edu/physics/courses.shtml#237>`__
+.. |phys237| replace:: `PHYS 237: Modern Physics Lab <http://www.luc.edu/physics/courses.shtml#237>`_
 
-.. |phys266| replace:: `PHYS 266: Digital Electronics Laboratory <http://www.luc.edu/physics/courses.shtml#266>`__
+.. |phys266| replace:: `PHYS 266: Digital Electronics Laboratory <http://www.luc.edu/physics/courses.shtml#266>`_
 
-.. |phys303| replace:: `PHYS 303: Electronics I <http://www.luc.edu/physics/courses.shtml#303>`__
+.. |phys303| replace:: `PHYS 303: Electronics I <http://www.luc.edu/physics/courses.shtml#303>`_
 
-.. |phys310| replace:: `PHYS 310: Optics <http://www.luc.edu/physics/courses.shtml#310>`__
+.. |phys310| replace:: `PHYS 310: Optics <http://www.luc.edu/physics/courses.shtml#310>`_
 
-.. |phys314| replace:: `PHYS 314: Theoretical Mechanics I <http://www.luc.edu/physics/courses.shtml#314>`__
+.. |phys314| replace:: `PHYS 314: Theoretical Mechanics I <http://www.luc.edu/physics/courses.shtml#314>`_
 
-.. |phys328| replace:: `PHYS 328: Thermal Physics & Statistical Mechanics <http://www.luc.edu/physics/courses.shtml#328>`__
+.. |phys328| replace:: `PHYS 328: Thermal Physics & Statistical Mechanics <http://www.luc.edu/physics/courses.shtml#328>`_
 
-.. |phys351| replace:: `PHYS 351: Electricity & Magnetism I <http://www.luc.edu/physics/courses.shtml#351>`__
+.. |phys351| replace:: `PHYS 351: Electricity & Magnetism I <http://www.luc.edu/physics/courses.shtml#351>`_
 
-.. |biol101| replace:: `BIOL 101: General Biology I <http://luc.edu/biology/bsinbiology/courseofferings/>`__
+.. |biol101| replace:: `BIOL 101: General Biology I <http://luc.edu/biology/bsinbiology/courseofferings/>`_
 
-.. |biol282| replace:: `BIOL 282: Genetics <http://luc.edu/biology/bsinbiology/courseofferings/>`__
+.. |biol282| replace:: `BIOL 282: Genetics <http://luc.edu/biology/bsinbiology/courseofferings/>`_
 
-.. |biol388| replace:: `BIOL 388: Bioinformatics <http://luc.edu/biology/bsinbiology/courseofferings/>`__
+.. |biol388| replace:: `BIOL 388: Bioinformatics <http://luc.edu/biology/bsinbiology/courseofferings/>`_
 
-.. |engl210| replace:: `ENGL 210: Business Writing <http://luc.edu/english/courses.shtml/>`__
+.. |engl210| replace:: `ENGL 210: Business Writing <http://luc.edu/english/courses.shtml/>`_
 
-.. |isscm241| replace:: `ISSCM 241: Business Statistics <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`__
+.. |isscm241| replace:: `ISSCM 241: Business Statistics <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`_
 
-.. |isscm349| replace:: `ISSCM 349 <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`__
+.. |isscm349| replace:: `ISSCM 349 <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`_
 
-.. |psyc101| replace:: `PSYC 101: General Psychology <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`__
+.. |psyc101| replace:: `PSYC 101: General Psychology <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`_
 
-.. |psyc304| replace:: `PSYC 304: Statistics <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`__
+.. |psyc304| replace:: `PSYC 304: Statistics <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`_
 
-.. |cjc101| replace:: `CJC 101: Criminal Justice in a Global Context <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
+.. |cjc101| replace:: `CJC 101: Criminal Justice in a Global Context <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
 
-.. |cjc102| replace:: `CJC 102: The Criminal Justice System <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
+.. |cjc102| replace:: `CJC 102: The Criminal Justice System <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
 
-.. |cjc322| replace:: `CJC 322: Criminal Courts and Law <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
+.. |cjc322| replace:: `CJC 322: Criminal Courts and Law <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
 
-.. |cjc323| replace:: `CJC 323: Criminal Procedure <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
+.. |cjc323| replace:: `CJC 323: Criminal Procedure <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
 
-.. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`__. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
+.. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`_. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
 
 .. |see-syllabi| replace:: See the :doc:`../syllabi/syllabi`.
 """

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,123 +18,123 @@ from datetime import date
 rst_epilog = (
     """
 
-.. |acct201| replace:: `ACCT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainaccounting/#692265>`_
+.. |acct201| replace:: `ACCT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainaccounting/#692265>`__
 
-.. |mgmt201| replace:: `MGMT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainmanagement/#675009>`_
+.. |mgmt201| replace:: `MGMT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainmanagement/#675009>`__
 
-.. |math100| replace:: `MATH 100: Intermediate Algebra <http://luc.edu/math/academics/courses/math100/index.shtml>`_
+.. |math100| replace:: `MATH 100: Intermediate Algebra <http://luc.edu/math/academics/courses/math100/index.shtml>`__
 
-.. |math117| replace:: `MATH 117: College Algebra <http://luc.edu/math/academics/courses/math117/index.shtml>`_
+.. |math117| replace:: `MATH 117: College Algebra <http://luc.edu/math/academics/courses/math117/index.shtml>`__
 
-.. |math118| replace:: `MATH 118: Precalculus <http://luc.edu/math/academics/courses/math118/index.shtml>`_
+.. |math118| replace:: `MATH 118: Precalculus <http://luc.edu/math/academics/courses/math118/index.shtml>`__
 
-.. |math131| replace:: `MATH 131: Applied Calculus I <http://luc.edu/math/academics/courses/math131/index.shtml>`_
+.. |math131| replace:: `MATH 131: Applied Calculus I <http://luc.edu/math/academics/courses/math131/index.shtml>`__
 
-.. |math132| replace:: `MATH 132: Applied Calculus II <http://luc.edu/math/academics/courses/math132/index.shtml>`_
+.. |math132| replace:: `MATH 132: Applied Calculus II <http://luc.edu/math/academics/courses/math132/index.shtml>`__
 
-.. |math161| replace:: `MATH 161: Calculus I <http://luc.edu/math/academics/courses/math161/index.shtml>`_
+.. |math161| replace:: `MATH 161: Calculus I <http://luc.edu/math/academics/courses/math161/index.shtml>`__
 
-.. |math162| replace:: `MATH 162: Calculus II <http://luc.edu/math/academics/courses/math162/index.shtml>`_
+.. |math162| replace:: `MATH 162: Calculus II <http://luc.edu/math/academics/courses/math162/index.shtml>`__
 
-.. |math201| replace:: `MATH 201: Introduction to Discrete Mathematics and Number Theory <http://luc.edu/math/academics/courses/math201/index.shtml>`_
+.. |math201| replace:: `MATH 201: Introduction to Discrete Mathematics and Number Theory <http://luc.edu/math/academics/courses/math201/index.shtml>`__
 
-.. |math212| replace:: `MATH 212: Linear Algebra <http://luc.edu/math/academics/courses/math212/index.shtml>`_
+.. |math212| replace:: `MATH 212: Linear Algebra <http://luc.edu/math/academics/courses/math212/index.shtml>`__
 
-.. |math215| replace:: `MATH 215: Object Oriented Math Programming <http://luc.edu/math/academics/courses/math215/index.shtml>`_
+.. |math215| replace:: `MATH 215: Object Oriented Math Programming <http://luc.edu/math/academics/courses/math215/index.shtml>`__
 
-.. |math263| replace:: `MATH 263: Multivariable Calculus <http://luc.edu/math/academics/courses/math263/index.shtml>`_
+.. |math263| replace:: `MATH 263: Multivariable Calculus <http://luc.edu/math/academics/courses/math263/index.shtml>`__
 
-.. |math264| replace:: `MATH 264: Ordinary Differential Equations <http://luc.edu/math/academics/courses/math264/index.shtml>`_
+.. |math264| replace:: `MATH 264: Ordinary Differential Equations <http://luc.edu/math/academics/courses/math264/index.shtml>`__
 
-.. |math304| replace:: `MATH 304: Probability and Statistics I <http://luc.edu/math/academics/courses/math304/index.shtml>`_
+.. |math304| replace:: `MATH 304: Probability and Statistics I <http://luc.edu/math/academics/courses/math304/index.shtml>`__
 
-.. |math309| replace:: `MATH 309: Numerical Methods <http://luc.edu/math/academics/courses/math309/index.shtml>`_
+.. |math309| replace:: `MATH 309: Numerical Methods <http://luc.edu/math/academics/courses/math309/index.shtml>`__
 
-.. |math313| replace:: `MATH 313: Abstract Algebra <http://luc.edu/math/academics/courses/math313/index.shtml>`_
+.. |math313| replace:: `MATH 313: Abstract Algebra <http://luc.edu/math/academics/courses/math313/index.shtml>`__
 
-.. |math314| replace:: `MATH 314: Advanced Topics in Abstract Algebra <http://luc.edu/math/academics/courses/math314/index.shtml>`_
+.. |math314| replace:: `MATH 314: Advanced Topics in Abstract Algebra <http://luc.edu/math/academics/courses/math314/index.shtml>`__
 
-.. |math315| replace:: `MATH 315: Advanced Topics in Linear Algebra <http://luc.edu/math/academics/courses/math315/index.shtml>`_
+.. |math315| replace:: `MATH 315: Advanced Topics in Linear Algebra <http://luc.edu/math/academics/courses/math315/index.shtml>`__
 
-.. |math328| replace:: `MATH 328: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math328/index.shtml>`_
+.. |math328| replace:: `MATH 328: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math328/index.shtml>`__
 
-.. |math331| replace:: `MATH 331: Cryptography <http://luc.edu/math/academics/courses/math331/index.shtml>`_
+.. |math331| replace:: `MATH 331: Cryptography <http://luc.edu/math/academics/courses/math331/index.shtml>`__
 
-.. |math351| replace:: `MATH 351: Introduction to Real Analysis I <http://luc.edu/math/academics/courses/math351/index.shtml>`_
+.. |math351| replace:: `MATH 351: Introduction to Real Analysis I <http://luc.edu/math/academics/courses/math351/index.shtml>`__
 
-.. |math352| replace:: `MATH 352: Introduction to Real Analysis II <http://luc.edu/math/academics/courses/math352/index.shtml>`_
+.. |math352| replace:: `MATH 352: Introduction to Real Analysis II <http://luc.edu/math/academics/courses/math352/index.shtml>`__
 
-.. |math353| replace:: `MATH 353: Introductory Complex Analysis <http://luc.edu/math/academics/courses/math353/index.shtml>`_
+.. |math353| replace:: `MATH 353: Introductory Complex Analysis <http://luc.edu/math/academics/courses/math353/index.shtml>`__
 
-.. |math409| replace:: `MATH 409: Advanced Numerical Anaylsis <http://luc.edu/math/academics/courses/math409/index.shtml>`_
+.. |math409| replace:: `MATH 409: Advanced Numerical Anaylsis <http://luc.edu/math/academics/courses/math409/index.shtml>`__
 
-.. |math428| replace:: `MATH 428: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math428/index.shtml>`_
+.. |math428| replace:: `MATH 428: Algebraic Coding Theory <http://luc.edu/math/academics/courses/math428/index.shtml>`__
 
-.. |stat103| replace:: `STAT 103: Fundamentals of Statistics <http://www.luc.edu/math/academics/courses/stat103/>`_
+.. |stat103| replace:: `STAT 103: Fundamentals of Statistics <http://www.luc.edu/math/academics/courses/stat103/>`__
 
-.. |stat203| replace:: `STAT 203: Statistics <http://luc.edu/math/academics/courses/stat203/index.shtml>`_
+.. |stat203| replace:: `STAT 203: Statistics <http://luc.edu/math/academics/courses/stat203/index.shtml>`__
 
-.. |stat304| replace:: `STAT 304: Probability and Statistics I <http://luc.edu/math/academics/courses/stat304/index.shtml>`_
+.. |stat304| replace:: `STAT 304: Probability and Statistics I <http://luc.edu/math/academics/courses/stat304/index.shtml>`__
 
-.. |phil120| replace:: `PHIL 120 <http://luc.edu/philosophy/coursedescriptions.shtml>`_
+.. |phil120| replace:: `PHIL 120 <http://luc.edu/philosophy/coursedescriptions.shtml>`__
 
-.. |phys112| replace:: `PHYS 112: College Physics II <http://www.luc.edu/physics/courses.shtml#112>`_
+.. |phys112| replace:: `PHYS 112: College Physics II <http://www.luc.edu/physics/courses.shtml#112>`__
 
-.. |phys125| replace:: `PHYS 125: General Physics I <http://www.luc.edu/physics/courses.shtml#125>`_
+.. |phys125| replace:: `PHYS 125: General Physics I <http://www.luc.edu/physics/courses.shtml#125>`__
 
-.. |phys126| replace:: `PHYS 126: General Physics II <http://www.luc.edu/physics/courses.shtml#126>`_
+.. |phys126| replace:: `PHYS 126: General Physics II <http://www.luc.edu/physics/courses.shtml#126>`__
 
-.. |phys135| replace:: `PHYS 135: General Physics Lab I <http://www.luc.edu/physics/courses.shtml#135>`_
+.. |phys135| replace:: `PHYS 135: General Physics Lab I <http://www.luc.edu/physics/courses.shtml#135>`__
 
-.. |phys136| replace:: `PHYS 136: General Physics Lab II <http://www.luc.edu/physics/courses.shtml#136>`_
+.. |phys136| replace:: `PHYS 136: General Physics Lab II <http://www.luc.edu/physics/courses.shtml#136>`__
 
-.. |phys235| replace:: `PHYS 235: Modern Physics <http://www.luc.edu/physics/courses.shtml#235>`_
+.. |phys235| replace:: `PHYS 235: Modern Physics <http://www.luc.edu/physics/courses.shtml#235>`__
 
-.. |phys237| replace:: `PHYS 237: Modern Physics Lab <http://www.luc.edu/physics/courses.shtml#237>`_
+.. |phys237| replace:: `PHYS 237: Modern Physics Lab <http://www.luc.edu/physics/courses.shtml#237>`__
 
-.. |phys266| replace:: `PHYS 266: Digital Electronics Laboratory <http://www.luc.edu/physics/courses.shtml#266>`_
+.. |phys266| replace:: `PHYS 266: Digital Electronics Laboratory <http://www.luc.edu/physics/courses.shtml#266>`__
 
-.. |phys303| replace:: `PHYS 303: Electronics I <http://www.luc.edu/physics/courses.shtml#303>`_
+.. |phys303| replace:: `PHYS 303: Electronics I <http://www.luc.edu/physics/courses.shtml#303>`__
 
-.. |phys310| replace:: `PHYS 310: Optics <http://www.luc.edu/physics/courses.shtml#310>`_
+.. |phys310| replace:: `PHYS 310: Optics <http://www.luc.edu/physics/courses.shtml#310>`__
 
-.. |phys314| replace:: `PHYS 314: Theoretical Mechanics I <http://www.luc.edu/physics/courses.shtml#314>`_
+.. |phys314| replace:: `PHYS 314: Theoretical Mechanics I <http://www.luc.edu/physics/courses.shtml#314>`__
 
-.. |phys328| replace:: `PHYS 328: Thermal Physics & Statistical Mechanics <http://www.luc.edu/physics/courses.shtml#328>`_
+.. |phys328| replace:: `PHYS 328: Thermal Physics & Statistical Mechanics <http://www.luc.edu/physics/courses.shtml#328>`__
 
-.. |phys351| replace:: `PHYS 351: Electricity & Magnetism I <http://www.luc.edu/physics/courses.shtml#351>`_
+.. |phys351| replace:: `PHYS 351: Electricity & Magnetism I <http://www.luc.edu/physics/courses.shtml#351>`__
 
-.. |phys366| replace:: `PHYS 366 <https://www.luc.edu/physics/courses.shtml#366>`_
+.. |phys366| replace:: `PHYS 366 <https://www.luc.edu/physics/courses.shtml#366>`__
 
-.. |biol101| replace:: `BIOL 101: General Biology I <http://luc.edu/biology/bsinbiology/courseofferings/>`_
+.. |biol101| replace:: `BIOL 101: General Biology I <http://luc.edu/biology/bsinbiology/courseofferings/>`__
 
-.. |biol102| replace:: `BIOL 102 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`_
+.. |biol102| replace:: `BIOL 102 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`__
 
-.. |biol282| replace:: `BIOL 282: Genetics <http://luc.edu/biology/bsinbiology/courseofferings/>`_
+.. |biol282| replace:: `BIOL 282: Genetics <http://luc.edu/biology/bsinbiology/courseofferings/>`__
 
-.. |biol388| replace:: `BIOL 388: Bioinformatics <http://luc.edu/biology/bsinbiology/courseofferings/>`_
+.. |biol388| replace:: `BIOL 388: Bioinformatics <http://luc.edu/biology/bsinbiology/courseofferings/>`__
 
-.. |engl210| replace:: `ENGL 210: Business Writing <http://luc.edu/english/courses.shtml/>`_
+.. |engl210| replace:: `ENGL 210: Business Writing <http://luc.edu/english/courses.shtml/>`__
 
-.. |isscm241| replace:: `ISSCM 241: Business Statistics <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`_
+.. |isscm241| replace:: `ISSCM 241: Business Statistics <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`__
 
-.. |isscm349| replace:: `ISSCM 349 <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`_
+.. |isscm349| replace:: `ISSCM 349 <http://www.luc.edu/quinlan/undergraduate/informationsystems/information_systems_courses.shtml>`__
 
-.. |psyc101| replace:: `PSYC 101: General Psychology <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`_
+.. |psyc101| replace:: `PSYC 101: General Psychology <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`__
 
-.. |psyc304| replace:: `PSYC 304: Statistics <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`_
+.. |psyc304| replace:: `PSYC 304: Statistics <http://www.luc.edu/psychology/course_offerings.shtml#d.en.76692>`__
 
-.. |cjc101| replace:: `CJC 101: Criminal Justice in a Global Context <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
+.. |cjc101| replace:: `CJC 101: Criminal Justice in a Global Context <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
 
-.. |cjc102| replace:: `CJC 102: The Criminal Justice System <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
+.. |cjc102| replace:: `CJC 102: The Criminal Justice System <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
 
-.. |cjc322| replace:: `CJC 322: Criminal Courts and Law <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
+.. |cjc322| replace:: `CJC 322: Criminal Courts and Law <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
 
-.. |cjc323| replace:: `CJC 323: Criminal Procedure <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`_
+.. |cjc323| replace:: `CJC 323: Criminal Procedure <http://www.luc.edu/criminaljustice/undergradcourses.shtml>`__
 
-.. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`_. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
+.. |see-locus| replace:: The scheduling information you see here is an export from `LOCUS <https://locus.luc.edu>`__. LOCUS is the authoritative source of information for university course scheduling. What you see here is subject to change at any time.
 
-.. |locus| replace::`Locus <https://locus.luc.edu>`_
+.. |short-locus| replace:: `LOCUS <https://locus.luc.edu>`__
 
 .. |see-syllabi| replace:: See the :doc:`../syllabi/syllabi`.
 """

--- a/source/courses/comp102.rst
+++ b/source/courses/comp102.rst
@@ -46,4 +46,4 @@ An understanding of the technologies behind web sites and the ability to use the
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp104.rst
+++ b/source/courses/comp104.rst
@@ -44,4 +44,4 @@ Ability to publish created animated media projects to the web in a process that 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp111.rst
+++ b/source/courses/comp111.rst
@@ -44,4 +44,4 @@ Students who complete this course will learn the key vocabulary of the computing
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp120.rst
+++ b/source/courses/comp120.rst
@@ -49,4 +49,4 @@ Experience with Internet tools, desktop publishing, spreadsheets, databases, sta
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp122.rst
+++ b/source/courses/comp122.rst
@@ -50,4 +50,4 @@ Students who complete this course will have:
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp125.rst
+++ b/source/courses/comp125.rst
@@ -44,4 +44,4 @@ Understanding of computer mechanisms for representing and analyzing numerical an
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp141.rst
+++ b/source/courses/comp141.rst
@@ -46,4 +46,4 @@ Students who complete this course will develop fluency in the Unix (Linux) envir
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp150.rst
+++ b/source/courses/comp150.rst
@@ -46,4 +46,4 @@ Empowerment to manage and transform masses of data; understanding of technical, 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp163.rst
+++ b/source/courses/comp163.rst
@@ -39,4 +39,4 @@ The student will be prepared for the study of advanced ideas in computer science
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp170.rst
+++ b/source/courses/comp170.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * |math131| or |math161| or :doc:`../courses/comp125` or :doc:`../courses/comp180` or permission from the instructor.
+    * |math131| or |math161| or :doc:`comp125` or :doc:`comp180` or permission from the instructor.
     * Recommended - Experience programming in a procedural or object-oriented language.
 
 About

--- a/source/courses/comp170.rst
+++ b/source/courses/comp170.rst
@@ -64,4 +64,4 @@ Upon successful completion of the course, the student will be able to:
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp171.rst
+++ b/source/courses/comp171.rst
@@ -44,4 +44,4 @@ Students will learn how a program can be put together quickly and efficiently to
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp180.rst
+++ b/source/courses/comp180.rst
@@ -46,4 +46,4 @@ At the end of this course, students will be well versed in the use of a specific
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp215.rst
+++ b/source/courses/comp215.rst
@@ -46,4 +46,4 @@ with the goal of being able to solve mathematical and scientific problems.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp231.rst
+++ b/source/courses/comp231.rst
@@ -47,4 +47,4 @@ Students will learn fundamental data structures and algorithms frequently used i
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp231.rst
+++ b/source/courses/comp231.rst
@@ -25,8 +25,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp215` or :doc:`../courses/comp170`
-    * :doc:`../courses/comp141`
+    * :doc:`comp215` or :doc:`comp170`
+    * :doc:`comp141`
 
 About
 =====

--- a/source/courses/comp250.rst
+++ b/source/courses/comp250.rst
@@ -53,4 +53,4 @@ Students will learn to write clear technical documentation.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp250.rst
+++ b/source/courses/comp250.rst
@@ -28,10 +28,10 @@ Course Information
 
     * One of the following:
 
-        * :doc:`../courses/comp125`
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp215`
+        * :doc:`comp125`
+        * :doc:`comp150`
+        * :doc:`comp170`
+        * :doc:`comp215`
 
 
 About

--- a/source/courses/comp251.rst
+++ b/source/courses/comp251.rst
@@ -27,10 +27,10 @@ Course Information
 
     * One of the following:
 
-        * :doc:`../courses/comp125`
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp215`
+        * :doc:`comp125`
+        * :doc:`comp150`
+        * :doc:`comp170`
+        * :doc:`comp215`
 
 About
 =====

--- a/source/courses/comp251.rst
+++ b/source/courses/comp251.rst
@@ -51,4 +51,4 @@ Students will organize data in ways to emphasize relationships, write simple pro
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp264.rst
+++ b/source/courses/comp264.rst
@@ -52,4 +52,4 @@ Understanding of system issues that affect the performance, correctness, or util
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp264.rst
+++ b/source/courses/comp264.rst
@@ -24,13 +24,13 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp141`
-    * :doc:`../courses/comp163`
-    * :doc:`../courses/comp170` or :doc:`../courses/comp215`
+    * :doc:`comp141`
+    * :doc:`comp163`
+    * :doc:`comp170` or :doc:`comp215`
 
     **Co-Requisites**
 
-    * :doc:`../courses/comp163`
+    * :doc:`comp163`
 
 
 About

--- a/source/courses/comp266.rst
+++ b/source/courses/comp266.rst
@@ -45,4 +45,4 @@ Students will gain an understanding of digital electronic components and amicrop
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp271.rst
+++ b/source/courses/comp271.rst
@@ -51,4 +51,4 @@ Students learn linear data structures and the performance of their operations, a
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp271.rst
+++ b/source/courses/comp271.rst
@@ -23,14 +23,14 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp141`
-    * :doc:`../courses/comp163` or |math201| or declared Bioinfomatics or SCPS student
-    * :doc:`../courses/comp170`
-    * or :doc:`../courses/comp215`
+    * :doc:`comp141`
+    * :doc:`comp163` or |math201| or declared Bioinfomatics or SCPS student
+    * :doc:`comp170`
+    * or :doc:`comp215`
 
     **Co-Requisites**
 
-    * :doc:`../courses/comp163`
+    * :doc:`comp163`
 
 About
 =====

--- a/source/courses/comp272.rst
+++ b/source/courses/comp272.rst
@@ -46,4 +46,4 @@ Students learn non-linear data structures and runtime performance of their opera
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp272.rst
+++ b/source/courses/comp272.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
-    * :doc:`../courses/comp163` or |math201|
+    * :doc:`comp271`
+    * :doc:`comp163` or |math201|
     * |math131| or |math161|
 
 About

--- a/source/courses/comp301.rst
+++ b/source/courses/comp301.rst
@@ -45,4 +45,4 @@ Students will learn to think like an adversary, find and exploit vulnerabilities
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp301.rst
+++ b/source/courses/comp301.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170`
+    * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp305.rst
+++ b/source/courses/comp305.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp305.rst
+++ b/source/courses/comp305.rst
@@ -43,4 +43,4 @@ Students will be able to use theory and pragmatic approaches to define and imple
 Syllabi
 =======
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp306.rst
+++ b/source/courses/comp306.rst
@@ -48,4 +48,4 @@ Students will be able to define and critically analyze data warehouse and mining
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp306.rst
+++ b/source/courses/comp306.rst
@@ -24,7 +24,7 @@ Course Information
 
     * One of more of the following:
 
-        * :doc:`../courses/comp231` or :doc:`../courses/comp251` or :doc:`../courses/comp271`
+        * :doc:`comp231` or :doc:`comp251` or :doc:`comp271`
         * |stat103| or |stat203| or |isscm241| or |psyc304| or instructor permission.
 
 About

--- a/source/courses/comp309.rst
+++ b/source/courses/comp309.rst
@@ -53,4 +53,4 @@ Students will have an understanding of numerical methods and their application.
 Syllabi
 ----------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp309.rst
+++ b/source/courses/comp309.rst
@@ -31,8 +31,8 @@ Course Information
     * |math264|
     * One or more of the following:
         * |math215|
-        * :doc:`../courses/comp215`
-        * :doc:`../courses/comp170`
+        * :doc:`comp215`
+        * :doc:`comp170`
 
 
 About

--- a/source/courses/comp310.rst
+++ b/source/courses/comp310.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` and :doc:`../courses/comp272`
+    * :doc:`comp264` and :doc:`comp272`
 
 About
 =====

--- a/source/courses/comp310.rst
+++ b/source/courses/comp310.rst
@@ -48,4 +48,4 @@ Students will learn the different parts of an operating system at a functional l
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp312.rst
+++ b/source/courses/comp312.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp312.rst
+++ b/source/courses/comp312.rst
@@ -45,4 +45,4 @@ Students will learn to implement projects involving Free and Open Source softwar
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp313.rst
+++ b/source/courses/comp313.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp272`
+    * :doc:`comp272`
 
 About
 =====
@@ -40,12 +40,12 @@ Object-orientation continues to be a dominant approach to software development. 
 Overall Series of Object-Oriented Courses
 -----------------------------------------
 
-* :doc:`../courses/comp170` (CS1) - simple objects representing scalars
-* :doc:`../courses/comp271` (CS2) - collections of simple objects
-* :doc:`../courses/comp313` / :doc:`../courses/comp413` - complex, interacting objects; basic design patterns
-* :doc:`../courses/comp373` / :doc:`../courses/comp473` - advanced design patterns and topics such as AOP(Aspect-Oriented programming)
+* :doc:`comp170` (CS1) - simple objects representing scalars
+* :doc:`comp271` (CS2) - collections of simple objects
+* :doc:`comp313` / :doc:`comp413` - complex, interacting objects; basic design patterns
+* :doc:`comp373` / :doc:`comp473` - advanced design patterns and topics such as AOP(Aspect-Oriented programming)
 
-:doc:`../courses/comp313` / :doc:`../courses/comp413` is also a prerequisite for other advanced software courses. Students interested in advanced software courses are encouraged to take :doc:`../courses/comp313` / :doc:`../courses/comp413` as soon as they have completed :doc:`../courses/comp271` so as to be eligible for these further courses.
+:doc:`comp313` / :doc:`comp413` is also a prerequisite for other advanced software courses. Students interested in advanced software courses are encouraged to take :doc:`comp313` / :doc:`comp413` as soon as they have completed :doc:`comp271` so as to be eligible for these further courses.
 
 Course Topics
 -------------

--- a/source/courses/comp313.rst
+++ b/source/courses/comp313.rst
@@ -77,4 +77,4 @@ You will learn to design and implement more complex programs using good software
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp314-315.rst
+++ b/source/courses/comp314-315.rst
@@ -70,4 +70,4 @@ Ability to work in small groups, quickly and accurately assessing and solving fo
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp314-315.rst
+++ b/source/courses/comp314-315.rst
@@ -35,11 +35,11 @@ Course Information
 
     * For COMP 314:
 
-        * :doc:`../courses/comp271`
+        * :doc:`comp271`
 
     * For COMP 315:
 
-        * :doc:`../courses/comp314-315`
+        * :doc:`comp314-315`
 
 About
 =====

--- a/source/courses/comp317.rst
+++ b/source/courses/comp317.rst
@@ -47,4 +47,4 @@ Understanding of laws and issues in areas such as privacy, encryption, freedom o
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp317.rst
+++ b/source/courses/comp317.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * Any :doc:`COMP<undergraduate-courses>` course
+    * Any :doc:`COMP 300 level <undergraduate-courses>` course
     * Any `Ethics <https://www.luc.edu/core/ethicscoursesub-first.shtml>`_ course
 
 About

--- a/source/courses/comp319.rst
+++ b/source/courses/comp319.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170`
+    * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp319.rst
+++ b/source/courses/comp319.rst
@@ -43,4 +43,4 @@ After taking this course, students will develop a working knowledge of Unix and 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp320.rst
+++ b/source/courses/comp320.rst
@@ -46,4 +46,4 @@ Students will be able to use techniques of analysis and design, document results
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp320.rst
+++ b/source/courses/comp320.rst
@@ -30,7 +30,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp163` **and** :doc:`../courses/comp170`
+    * :doc:`comp163` **and** :doc:`comp170`
 
 Description
 ===========

--- a/source/courses/comp322.rst
+++ b/source/courses/comp322.rst
@@ -51,4 +51,4 @@ Students will be able to develop applications for mobile and portable devices.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp322.rst
+++ b/source/courses/comp322.rst
@@ -30,7 +30,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp323.rst
+++ b/source/courses/comp323.rst
@@ -49,4 +49,4 @@ Students will acquire an awareness of different game design and development meth
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp323.rst
+++ b/source/courses/comp323.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp324.rst
+++ b/source/courses/comp324.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp324.rst
+++ b/source/courses/comp324.rst
@@ -48,4 +48,4 @@ We shall also consider client-side usage of tools and technologies such as Node.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp325.rst
+++ b/source/courses/comp325.rst
@@ -47,4 +47,4 @@ Students will gain enhanced skills in object-oriented programming and developmen
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp325.rst
+++ b/source/courses/comp325.rst
@@ -26,7 +26,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp328.rst
+++ b/source/courses/comp328.rst
@@ -50,4 +50,4 @@ Students will learn both the theory and application of error-correcting codes.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp329.rst
+++ b/source/courses/comp329.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
     * |math131| or |math161|
     * One or more of the following:
         * |stat103|

--- a/source/courses/comp329.rst
+++ b/source/courses/comp329.rst
@@ -54,4 +54,4 @@ Syllabi
 *******
 
 There is no syllabus at this time.
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp330.rst
+++ b/source/courses/comp330.rst
@@ -44,4 +44,4 @@ Students will experience process-based development, understand the dynamics of a
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp330.rst
+++ b/source/courses/comp330.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp331.rst
+++ b/source/courses/comp331.rst
@@ -29,12 +29,12 @@ Course Information
 
     **Prerequisites**
 
-    * |math201| or :doc:`../courses/comp363`
+    * |math201| or :doc:`comp363`
     * One or more of the following:
-        * :doc:`../courses/comp125`
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp215`
+        * :doc:`comp125`
+        * :doc:`comp150`
+        * :doc:`comp170`
+        * :doc:`comp215`
 
 About
 =====

--- a/source/courses/comp331.rst
+++ b/source/courses/comp331.rst
@@ -55,4 +55,4 @@ Students will gain an understanding of cryptosystems widely used to protect data
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp332.rst
+++ b/source/courses/comp332.rst
@@ -43,4 +43,4 @@ Students will learn and apply the current state of the art in requirements engin
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp332.rst
+++ b/source/courses/comp332.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp330`
+    * :doc:`comp330`
 
 About
 =====

--- a/source/courses/comp333.rst
+++ b/source/courses/comp333.rst
@@ -46,4 +46,4 @@ This course studies the architectures, frameworks, and tools required to develop
 Syllabus
 ********
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp333.rst
+++ b/source/courses/comp333.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp335.rst
+++ b/source/courses/comp335.rst
@@ -27,7 +27,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp335.rst
+++ b/source/courses/comp335.rst
@@ -48,4 +48,4 @@ An understanding of the role of formal methods in the construction of software s
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp336.rst
+++ b/source/courses/comp336.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp336.rst
+++ b/source/courses/comp336.rst
@@ -50,4 +50,4 @@ After taking this course, students will have a working knowledge of XML and its 
 Syllabus
 ********
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp337.rst
+++ b/source/courses/comp337.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp337.rst
+++ b/source/courses/comp337.rst
@@ -44,4 +44,4 @@ An in-depth understanding of event-based and thread-based views of concurrency; 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp338.rst
+++ b/source/courses/comp338.rst
@@ -26,8 +26,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp313`
+    * :doc:`comp264`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp338.rst
+++ b/source/courses/comp338.rst
@@ -48,4 +48,4 @@ An understanding of software architecture and integration in the development of 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp339.rst
+++ b/source/courses/comp339.rst
@@ -46,4 +46,4 @@ After taking this course, students should understand the essential ingredients o
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp339.rst
+++ b/source/courses/comp339.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313` or :doc:`../courses/comp310` or :doc:`../courses/comp363`
+    * :doc:`comp313` or :doc:`comp310` or :doc:`comp363`
 
 About
 =====

--- a/source/courses/comp340.rst
+++ b/source/courses/comp340.rst
@@ -52,4 +52,4 @@ The student will learn Computer Software and hardware relevant for analysis and 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp340.rst
+++ b/source/courses/comp340.rst
@@ -24,14 +24,14 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp215`
+        * :doc:`comp150`
+        * :doc:`comp170`
+        * :doc:`comp215`
         * |math215|
     * One or more of the following:
-        * :doc:`../courses/comp264`
-        * :doc:`../courses/comp317`
-        * :doc:`../courses/comp343`
+        * :doc:`comp264`
+        * :doc:`comp317`
+        * :doc:`comp343`
 
 About
 =====

--- a/source/courses/comp341.rst
+++ b/source/courses/comp341.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp341.rst
+++ b/source/courses/comp341.rst
@@ -46,4 +46,4 @@ Students will acquire an awareness of different design and evaluation methods as
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp342.rst
+++ b/source/courses/comp342.rst
@@ -48,4 +48,4 @@ Students will be able to create webpages using JavaScript and related tools and 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp342.rst
+++ b/source/courses/comp342.rst
@@ -27,7 +27,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170`
+    * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp343.rst
+++ b/source/courses/comp343.rst
@@ -44,4 +44,4 @@ Students will understand how the Internet is constructed, how data is routed to 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp343.rst
+++ b/source/courses/comp343.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp271`
+    * :doc:`comp264` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp344.rst
+++ b/source/courses/comp344.rst
@@ -46,4 +46,4 @@ TBD
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp344.rst
+++ b/source/courses/comp344.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp301`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp345.rst
+++ b/source/courses/comp345.rst
@@ -48,4 +48,4 @@ It introduces the Internet of Things (IoT) comprising embedded devices and cloud
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp345.rst
+++ b/source/courses/comp345.rst
@@ -29,7 +29,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp301`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp346.rst
+++ b/source/courses/comp346.rst
@@ -44,4 +44,4 @@ Students will understand how modern telephone systems work.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp346.rst
+++ b/source/courses/comp346.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp271`
+    * :doc:`comp264` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp347.rst
+++ b/source/courses/comp347.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp150` or :doc:`../courses/comp170` or :doc:`../courses/comp215`
-    * :doc:`../courses/comp301`
+    * :doc:`comp150` or :doc:`comp170` or :doc:`comp215`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp347.rst
+++ b/source/courses/comp347.rst
@@ -45,4 +45,4 @@ Students will learn to configure ID systems (e.g. SNORT) and analyze their outpu
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp348.rst
+++ b/source/courses/comp348.rst
@@ -22,7 +22,7 @@ Course Information
     * 3
 
     **Prerequisites**
-    * :doc:`../courses/comp301`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp348.rst
+++ b/source/courses/comp348.rst
@@ -43,4 +43,4 @@ An understanding of how to secure networks using encryption, authentication, fir
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp349.rst
+++ b/source/courses/comp349.rst
@@ -46,4 +46,4 @@ Students will gain an understanding of wireless networking, protocols, and stand
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp349.rst
+++ b/source/courses/comp349.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp301`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp351.rst
+++ b/source/courses/comp351.rst
@@ -47,4 +47,4 @@ Students will become familiar with the SNMP protocol, with how large-scale Netwo
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp351.rst
+++ b/source/courses/comp351.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp271`
+    * :doc:`comp264` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp352.rst
+++ b/source/courses/comp352.rst
@@ -46,4 +46,4 @@ Run a virus in a virtual-machine sandbox with appropriate monitoring.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp352.rst
+++ b/source/courses/comp352.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` and :doc:`../courses/comp301`
+    * :doc:`comp264` and :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp353.rst
+++ b/source/courses/comp353.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp353.rst
+++ b/source/courses/comp353.rst
@@ -44,4 +44,4 @@ Students will learn SQL, database design, and application development using the 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp356.rst
+++ b/source/courses/comp356.rst
@@ -29,8 +29,8 @@ Course Information
     * |stat203|
     * One or more of the following:
         * |math215|
-        * :doc:`../courses/comp215`
-        * :doc:`../courses/comp170`
+        * :doc:`comp215`
+        * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp356.rst
+++ b/source/courses/comp356.rst
@@ -51,4 +51,4 @@ The objective is to provide management with relevant information for constructin
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp362.rst
+++ b/source/courses/comp362.rst
@@ -54,4 +54,4 @@ A basic understanding of how computers work at many levels and how to use variou
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp363.rst
+++ b/source/courses/comp363.rst
@@ -46,4 +46,4 @@ The ability to design and analyze efficient algorithms; understanding of the nec
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp363.rst
+++ b/source/courses/comp363.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp272`
+    * :doc:`comp272`
     * |math131| or |math161|
 
 About

--- a/source/courses/comp364.rst
+++ b/source/courses/comp364.rst
@@ -47,4 +47,4 @@ Students will learn how to engineer solutions to practical problems in multiproc
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp364.rst
+++ b/source/courses/comp364.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp272`
+    * :doc:`comp264`
+    * :doc:`comp272`
 
 About
 =====

--- a/source/courses/comp366.rst
+++ b/source/courses/comp366.rst
@@ -49,4 +49,4 @@ An exposure to microcomputer design and interfacing.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp366.rst
+++ b/source/courses/comp366.rst
@@ -20,7 +20,7 @@ Course Information
 
     **Alias**
 
-    * `PHYS 366 <https://www.luc.edu/physics/courses.shtml#366>`_
+    * |phys366|
 
     **Credit Hours**
 

--- a/source/courses/comp367.rst
+++ b/source/courses/comp367.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`.
-    * :doc:`../courses/comp313`
+    * :doc:`comp271`.
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp367.rst
+++ b/source/courses/comp367.rst
@@ -45,4 +45,4 @@ Students will explore the history of robotics, overview the theory of autonomous
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp369.rst
+++ b/source/courses/comp369.rst
@@ -45,4 +45,4 @@ Students will be able to visualize ideas via sketching basic shapes, create 3D m
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp370.rst
+++ b/source/courses/comp370.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp330`
+    * :doc:`comp330`
 
 About
 =====

--- a/source/courses/comp370.rst
+++ b/source/courses/comp370.rst
@@ -54,4 +54,4 @@ As well as:
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp371.rst
+++ b/source/courses/comp371.rst
@@ -45,4 +45,4 @@ An understanding of key principles and paradigms underlying the design and imple
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp371.rst
+++ b/source/courses/comp371.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp272`
+    * :doc:`comp264`
+    * :doc:`comp272`
 
 About
 =====

--- a/source/courses/comp373.rst
+++ b/source/courses/comp373.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp373.rst
+++ b/source/courses/comp373.rst
@@ -73,4 +73,4 @@ Proficiency in the use of object-oriented languages, frameworks, and patterns; a
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp376.rst
+++ b/source/courses/comp376.rst
@@ -47,4 +47,4 @@ An understanding of the theoretical underpinnings of computability and complexit
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp376.rst
+++ b/source/courses/comp376.rst
@@ -24,7 +24,7 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp163`
+        * :doc:`comp163`
         * |math201|
         * |math212|
 

--- a/source/courses/comp377.rst
+++ b/source/courses/comp377.rst
@@ -42,4 +42,4 @@ Students will learn time management, work-flow management, and team dynamics to 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp377.rst
+++ b/source/courses/comp377.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp378.rst
+++ b/source/courses/comp378.rst
@@ -21,8 +21,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231`
-    * :doc:`../courses/comp271`
+    * :doc:`comp231`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp378.rst
+++ b/source/courses/comp378.rst
@@ -43,4 +43,4 @@ The student will learn the basic theory of artificial intelligence and be able t
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp379.rst
+++ b/source/courses/comp379.rst
@@ -21,7 +21,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
     * One or more of the following:
         * |stat103|
         * |stat203|

--- a/source/courses/comp379.rst
+++ b/source/courses/comp379.rst
@@ -46,4 +46,4 @@ Students in this course will learn how to apply sophisticated algorithms to larg
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp380.rst
+++ b/source/courses/comp380.rst
@@ -53,4 +53,4 @@ The student will learn how to program real-time interactive applications using l
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp380.rst
+++ b/source/courses/comp380.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp381.rst
+++ b/source/courses/comp381.rst
@@ -21,8 +21,8 @@ Course Information
 
     **Prerequisites**
 
-    * `BIOL 101 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`_ (or equivalent)
-    * `BIOL 102 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`_
+    * |biol101| (or equivalent)
+    * |biol102|
 
 About
 =====

--- a/source/courses/comp381.rst
+++ b/source/courses/comp381.rst
@@ -43,4 +43,4 @@ Students will be able to apply their understanding of genetic and evolutionary p
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp382.rst
+++ b/source/courses/comp382.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp272`
+    * :doc:`comp264`
+    * :doc:`comp272`
 
 About
 =====

--- a/source/courses/comp382.rst
+++ b/source/courses/comp382.rst
@@ -45,4 +45,4 @@ Students will learn how a compiler is built.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp383.rst
+++ b/source/courses/comp383.rst
@@ -44,4 +44,4 @@ Students will learn, in detail, foundational methods and algorithms in bioinform
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp383.rst
+++ b/source/courses/comp383.rst
@@ -22,8 +22,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
-    * :doc:`../courses/comp381` or |biol388|
+    * :doc:`comp231` or :doc:`comp271`
+    * :doc:`comp381` or |biol388|
 
 About
 =====

--- a/source/courses/comp386.rst
+++ b/source/courses/comp386.rst
@@ -23,8 +23,8 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
+        * :doc:`comp150`
+        * :doc:`comp170`
         * Instructor permission
 
 About

--- a/source/courses/comp386.rst
+++ b/source/courses/comp386.rst
@@ -46,4 +46,4 @@ An appreciation that many aspects of neuroscience cannot be understood without a
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp388.rst
+++ b/source/courses/comp388.rst
@@ -53,4 +53,4 @@ Understand an emerging area of Computer Science.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp388.rst
+++ b/source/courses/comp388.rst
@@ -35,8 +35,8 @@ Description
 
 This course is used to introduce emerging topics in computer science that do not yet have a regular course number. The content of the course varies. Recent topics have included:
 
-* Foundations of Computer Science I (mostly an accelerated :doc:`../courses/comp170`)
-* Foundations of Computer Science II (mostly an accelerated :doc:`../courses/comp271`)
+* Foundations of Computer Science I (mostly an accelerated :doc:`comp170`)
+* Foundations of Computer Science II (mostly an accelerated :doc:`comp271`)
 * Enterprise Software Development
 * Rapid Application Development Methodology (.NET)
 * Robotics Software Development

--- a/source/courses/comp390.rst
+++ b/source/courses/comp390.rst
@@ -46,4 +46,4 @@ Students gain first-hand experience with broadening STEM participation and see h
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp391.rst
+++ b/source/courses/comp391.rst
@@ -70,4 +70,4 @@ Application of classroom skills to real-world situations.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp392.rst
+++ b/source/courses/comp392.rst
@@ -42,4 +42,4 @@ Students will gain hands-on experience with metagenomic methodologies while work
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp392.rst
+++ b/source/courses/comp392.rst
@@ -21,7 +21,8 @@ Course Information
 
     **Prerequisites**
 
-    * `BIOL 282 <https://www.luc.edu/biology/bsinbiology/courseofferings/>`_ **and** Instructor Permission
+    * |biol282|
+    * Instructor Permission
 
 About
 =====

--- a/source/courses/comp395.rst
+++ b/source/courses/comp395.rst
@@ -45,4 +45,4 @@ Students should acquire skills to professionally brand themselves, successfully 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp397.rst
+++ b/source/courses/comp397.rst
@@ -47,4 +47,4 @@ Regular progress on research projects and final presentations of results for a d
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp398.rst
+++ b/source/courses/comp398.rst
@@ -57,4 +57,4 @@ Knowledge of an advanced topic.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp399.rst
+++ b/source/courses/comp399.rst
@@ -47,4 +47,4 @@ Students will be exposed to a wide range of topics in computer science, particip
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp400a.rst
+++ b/source/courses/comp400a.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * |math118| or :doc:`../courses/comp125` or :doc:`../courses/comp150` or :doc:`../courses/comp163` or :doc:`../courses/comp400e` or permission from the instructor.
+    * |math118| or :doc:`comp125` or :doc:`comp150` or :doc:`comp163` or :doc:`comp400e` or permission from the instructor.
     * Recommended - Experience programming in a procedural or object-oriented language.
 
 About

--- a/source/courses/comp400a.rst
+++ b/source/courses/comp400a.rst
@@ -36,7 +36,7 @@ This programming-intensive course provides a foundation for computer programming
 Description
 ===========
 
-This course provides a foundation for computer programming using the Java object-oriented (OO) programming language. 
+This course provides a foundation for computer programming using the Java object-oriented (OO) programming language.
 
 The course addresses the following questions:
 
@@ -64,4 +64,4 @@ Upon successful completion of the course, the student will be able to:
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp400b.rst
+++ b/source/courses/comp400b.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170` or :doc:`../courses/comp215` or :doc:`../courses/comp400a`
+    * :doc:`comp170` or :doc:`comp215` or :doc:`comp400a`
 
 About
 =====

--- a/source/courses/comp400b.rst
+++ b/source/courses/comp400b.rst
@@ -46,4 +46,4 @@ Students will be able to describe linear data structures and analyze the perform
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp400c.rst
+++ b/source/courses/comp400c.rst
@@ -23,9 +23,9 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170` or :doc:`../courses/comp215` or :doc:`../courses/comp400a`
-    * :doc:`../courses/comp271` or :doc:`../courses/comp400b`
-    * :doc:`../courses/comp141` or :doc:`../courses/comp400d`
+    * :doc:`comp170` or :doc:`comp215` or :doc:`comp400a`
+    * :doc:`comp271` or :doc:`comp400b`
+    * :doc:`comp141` or :doc:`comp400d`
     * |math131| or |math161|
 
 

--- a/source/courses/comp400c.rst
+++ b/source/courses/comp400c.rst
@@ -48,4 +48,4 @@ Students learn non-linear data structures and runtime performance of their opera
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp400d.rst
+++ b/source/courses/comp400d.rst
@@ -46,4 +46,4 @@ Students who complete this course will develop fluency in the Unix (Linux) envir
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp400e.rst
+++ b/source/courses/comp400e.rst
@@ -40,4 +40,4 @@ The student will be prepared for the study of advanced ideas in computer science
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp401.rst
+++ b/source/courses/comp401.rst
@@ -45,4 +45,4 @@ Students will learn to think like an adversary, find and exploit vulnerabilities
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp401.rst
+++ b/source/courses/comp401.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp170`
+    * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp403.rst
+++ b/source/courses/comp403.rst
@@ -21,7 +21,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp150` or :doc:`../courses/comp170`
+    * :doc:`comp150` or :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp403.rst
+++ b/source/courses/comp403.rst
@@ -41,4 +41,4 @@ Understanding of the role of operations management in organizations, and applyin
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp404.rst
+++ b/source/courses/comp404.rst
@@ -32,8 +32,8 @@ This course will cover organization development with a focus in Information Tech
 Description
 ===========
 
- 	
-This course focuses on the manager's role in leading Organization Development and Change to maximize organization and individual effectiveness with a focus on Information Technology.  The class explores Organization Development and Change theory, change practices, and discusses considerations a manager will face as a change agent in today's computing ecosystem.  
+
+This course focuses on the manager's role in leading Organization Development and Change to maximize organization and individual effectiveness with a focus on Information Technology.  The class explores Organization Development and Change theory, change practices, and discusses considerations a manager will face as a change agent in today's computing ecosystem.
 
 Outcome
 =======
@@ -44,4 +44,4 @@ To understand the dynamics of change in organizations; learn techniques and stra
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp404.rst
+++ b/source/courses/comp404.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp405.rst
+++ b/source/courses/comp405.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp405.rst
+++ b/source/courses/comp405.rst
@@ -44,4 +44,4 @@ Students will be able to use theory and pragmatic approaches to define and imple
 Syllabi
 =======
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp406.rst
+++ b/source/courses/comp406.rst
@@ -43,4 +43,4 @@ Students can define and critically analyze data mining approaches for fields suc
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp406.rst
+++ b/source/courses/comp406.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp251` or :doc:`../courses/comp271`
+    * :doc:`comp251` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp409.rst
+++ b/source/courses/comp409.rst
@@ -51,4 +51,4 @@ Students will have an understanding of advanced numerical analysis and its appli
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp409.rst
+++ b/source/courses/comp409.rst
@@ -30,7 +30,7 @@ Course Information
 
     * |math212|
     * |math264|
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp410.rst
+++ b/source/courses/comp410.rst
@@ -22,8 +22,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp271`
+    * :doc:`comp264`
+    * :doc:`comp271`
 
 
 About

--- a/source/courses/comp410.rst
+++ b/source/courses/comp410.rst
@@ -51,4 +51,4 @@ The course covers: processes and threads (particularly the concepts of kernel th
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp412.rst
+++ b/source/courses/comp412.rst
@@ -43,4 +43,4 @@ Students will work on a significant development project involving free and open-
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp412.rst
+++ b/source/courses/comp412.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp413.rst
+++ b/source/courses/comp413.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====
@@ -36,14 +36,14 @@ Description
 
 **Overall Series of Object-Oriented Courses**
 
-* :doc:`../courses/comp170` (CS1) - simple objects representing scalars
-* :doc:`../courses/comp271` (CS2) - collections of simple objects
-* :doc:`../courses/comp313` / :doc:`../courses/comp413` - complex, interacting objects; basic design patterns
-* :doc:`../courses/comp373` / :doc:`../courses/comp473` - advanced design patterns and topics such as AOP(Aspect-Oriented programming)
+* :doc:`comp170` (CS1) - simple objects representing scalars
+* :doc:`comp271` (CS2) - collections of simple objects
+* :doc:`comp313` / :doc:`comp413` - complex, interacting objects; basic design patterns
+* :doc:`comp373` / :doc:`comp473` - advanced design patterns and topics such as AOP(Aspect-Oriented programming)
 
 
 .. note::
-    :doc:`../courses/comp313` / :doc:`../courses/comp413` is also a prerequisite for other advanced software courses. Students interested in advanced software courses are encouraged to take :doc:`../courses/comp313` / :doc:`../courses/comp413` as soon as they have completed :doc:`../courses/comp271` so as to be eligible for these further courses.
+    :doc:`comp313` / :doc:`comp413` is also a prerequisite for other advanced software courses. Students interested in advanced software courses are encouraged to take :doc:`comp313` / :doc:`comp413` as soon as they have completed :doc:`comp271` so as to be eligible for these further courses.
 
 **Course Topics**
 

--- a/source/courses/comp413.rst
+++ b/source/courses/comp413.rst
@@ -73,4 +73,4 @@ You will learn to design and implement more complex programs using good software
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp417.rst
+++ b/source/courses/comp417.rst
@@ -43,4 +43,4 @@ An understandin of the ethical issues that involve the field of Computer Science
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp418.rst
+++ b/source/courses/comp418.rst
@@ -48,4 +48,4 @@ We plan to examine the following topics: permutations and combinations, the incl
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp420.rst
+++ b/source/courses/comp420.rst
@@ -19,7 +19,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp420.rst
+++ b/source/courses/comp420.rst
@@ -39,4 +39,4 @@ Students will have an udnerstanding of UML and its applications.
 Syllabi
 ----------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp421.rst
+++ b/source/courses/comp421.rst
@@ -28,8 +28,8 @@ Course Information
     * |math132| or |math162|
     * One or more of the following:
         * |math215|
-        * :doc:`../courses/comp215`
-        * :doc:`../courses/comp170`
+        * :doc:`comp215`
+        * :doc:`comp170`
 
 About
 =====

--- a/source/courses/comp421.rst
+++ b/source/courses/comp421.rst
@@ -50,4 +50,4 @@ The objective is to provide management with relevant information for constructin
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp422.rst
+++ b/source/courses/comp422.rst
@@ -46,4 +46,4 @@ Students will learn how to create a mobile application.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp422.rst
+++ b/source/courses/comp422.rst
@@ -25,7 +25,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp424.rst
+++ b/source/courses/comp424.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp424.rst
+++ b/source/courses/comp424.rst
@@ -47,4 +47,4 @@ Students will acquire an awareness of different client-side design and developme
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp425.rst
+++ b/source/courses/comp425.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp425.rst
+++ b/source/courses/comp425.rst
@@ -44,4 +44,4 @@ Students will create database applications using server-side technologies.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp428.rst
+++ b/source/courses/comp428.rst
@@ -50,4 +50,4 @@ Students will learn both the theory and application of error-correcting codes.
 Syllabi
 ----------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp428.rst
+++ b/source/courses/comp428.rst
@@ -29,7 +29,7 @@ Course Information
     **Prerequisites**
 
     * |math212|
-    * :doc:`../courses/comp163` or |math313|
+    * :doc:`comp163` or |math313|
 
 
 About

--- a/source/courses/comp429.rst
+++ b/source/courses/comp429.rst
@@ -48,4 +48,4 @@ Outcome
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp429.rst
+++ b/source/courses/comp429.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp231` or :doc:`../courses/comp271`
+    * :doc:`comp231` or :doc:`comp271`
     * |math131| or |math161|
     * |stat103| or |stat203| or |isscm241| or |psyc304| or instructor permission
 

--- a/source/courses/comp431.rst
+++ b/source/courses/comp431.rst
@@ -22,9 +22,9 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
     * One or more of the following:
-        * :doc:`../courses/comp163`
+        * :doc:`comp163`
         * |math313|
         * |math201|
 

--- a/source/courses/comp431.rst
+++ b/source/courses/comp431.rst
@@ -47,4 +47,4 @@ Students will understand how and why cryptography is used and the theory behind 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp433.rst
+++ b/source/courses/comp433.rst
@@ -59,4 +59,4 @@ This course studies the architectures, frameworks, and tools required to develop
 Syllabus
 ********
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp433.rst
+++ b/source/courses/comp433.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp413`
+    * :doc:`comp413`
     * Instructor permission if the prerequisite is missing
 
 About

--- a/source/courses/comp434.rst
+++ b/source/courses/comp434.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp434.rst
+++ b/source/courses/comp434.rst
@@ -45,4 +45,4 @@ Students will be able to build enterprise software.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp436.rst
+++ b/source/courses/comp436.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 
 About

--- a/source/courses/comp436.rst
+++ b/source/courses/comp436.rst
@@ -50,4 +50,4 @@ An understanding of Markup languages and their applications.
 Syllabus
 ---------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp437.rst
+++ b/source/courses/comp437.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp437.rst
+++ b/source/courses/comp437.rst
@@ -45,4 +45,4 @@ Students will have an uderstanding of process algebras, formal specification,, t
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp439.rst
+++ b/source/courses/comp439.rst
@@ -46,4 +46,4 @@ Students will have an understanding of various distributed frameworks and techno
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp439.rst
+++ b/source/courses/comp439.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313` or :doc:`../courses/comp310`
+    * :doc:`comp313` or :doc:`comp310`
 
 About
 =====

--- a/source/courses/comp440.rst
+++ b/source/courses/comp440.rst
@@ -52,4 +52,4 @@ The student will learn Computer Software and hardware relevant for analysis and 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp440.rst
+++ b/source/courses/comp440.rst
@@ -24,14 +24,14 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp150`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp215`
+        * :doc:`comp150`
+        * :doc:`comp170`
+        * :doc:`comp215`
         * |math215|
     * One or more of the following:
-        * :doc:`../courses/comp264`
-        * :doc:`../courses/comp317`
-        * :doc:`../courses/comp343`
+        * :doc:`comp264`
+        * :doc:`comp317`
+        * :doc:`comp343`
 
 About
 =====

--- a/source/courses/comp441.rst
+++ b/source/courses/comp441.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp441.rst
+++ b/source/courses/comp441.rst
@@ -45,4 +45,4 @@ Students will acquire an awareness of different design and evaluation methods as
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp442.rst
+++ b/source/courses/comp442.rst
@@ -46,4 +46,4 @@ Pervasive issues such as integration, testing, security, and performance are dis
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp442.rst
+++ b/source/courses/comp442.rst
@@ -24,8 +24,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp313`
+    * :doc:`comp264`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp443.rst
+++ b/source/courses/comp443.rst
@@ -44,4 +44,4 @@ The course introduces basic issues in network security and real-time communicati
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp443.rst
+++ b/source/courses/comp443.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp271`
+    * :doc:`comp264` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp445.rst
+++ b/source/courses/comp445.rst
@@ -48,4 +48,4 @@ It introduces the Internet of Things (IoT) comprising embedded devices and cloud
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp445.rst
+++ b/source/courses/comp445.rst
@@ -29,7 +29,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp301`
+    * :doc:`comp301`
 
 About
 =====

--- a/source/courses/comp446.rst
+++ b/source/courses/comp446.rst
@@ -45,4 +45,4 @@ Underlying engineering principles of telephone networks, computer networks and i
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp446.rst
+++ b/source/courses/comp446.rst
@@ -23,8 +23,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp271`
+    * :doc:`comp264`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp447.rst
+++ b/source/courses/comp447.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp447.rst
+++ b/source/courses/comp447.rst
@@ -43,4 +43,4 @@ Students will learn to configure ID systems (eg., snort) and analyze their outpu
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp448.rst
+++ b/source/courses/comp448.rst
@@ -48,4 +48,4 @@ The goal is to gain an understanding of how to secure computers and computing en
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp448.rst
+++ b/source/courses/comp448.rst
@@ -25,9 +25,9 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp264`
-        * :doc:`../courses/comp170`
-        * :doc:`../courses/comp447`
+        * :doc:`comp264`
+        * :doc:`comp170`
+        * :doc:`comp447`
 
 About
 =====

--- a/source/courses/comp449.rst
+++ b/source/courses/comp449.rst
@@ -45,4 +45,4 @@ Students will have an understanding of wireless networks and the security issues
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp449.rst
+++ b/source/courses/comp449.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp343` or instructor permission
+    * :doc:`comp343` or instructor permission
 
 About
 =====

--- a/source/courses/comp450.rst
+++ b/source/courses/comp450.rst
@@ -30,8 +30,8 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp264`
-        * :doc:`../courses/comp271`
+        * :doc:`comp264`
+        * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp450.rst
+++ b/source/courses/comp450.rst
@@ -52,4 +52,4 @@ Students will have an understanding of microprocessor design and interfacing.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp450.rst
+++ b/source/courses/comp450.rst
@@ -21,7 +21,7 @@ Course Information
 
     **Alias**
 
-    * `PHYS 366 <https://www.luc.edu/physics/courses.shtml#366>`_
+    * |phys366|
 
     **Credit Hours**
 

--- a/source/courses/comp451.rst
+++ b/source/courses/comp451.rst
@@ -58,4 +58,4 @@ Students will become familiar with the SNMP protocol, with how large-scale Netwo
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp451.rst
+++ b/source/courses/comp451.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp271`
+    * :doc:`comp264` or :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp452.rst
+++ b/source/courses/comp452.rst
@@ -46,4 +46,4 @@ Run a virus in a virtual-machine sandbox with appropriate monitoring.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp452.rst
+++ b/source/courses/comp452.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` and :doc:`../courses/comp347`
+    * :doc:`comp264` and :doc:`comp347`
 
 About
 =====

--- a/source/courses/comp453.rst
+++ b/source/courses/comp453.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp453.rst
+++ b/source/courses/comp453.rst
@@ -44,4 +44,4 @@ Students will have an understanding of database programming and administration.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp458.rst
+++ b/source/courses/comp458.rst
@@ -45,4 +45,4 @@ Python or R will be used with parallel frameworks to perform proper model select
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp458.rst
+++ b/source/courses/comp458.rst
@@ -22,8 +22,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp405` or :doc:`../courses/comp453`
-    * :doc:`../courses/comp406` or :doc:`../courses/comp479` or |stat338| or |stat408|
+    * :doc:`comp405` or :doc:`comp453`
+    * :doc:`comp406` or :doc:`comp479` or |stat338| or |stat408|
     * Instructor permission
 
 About

--- a/source/courses/comp460.rst
+++ b/source/courses/comp460.rst
@@ -44,4 +44,4 @@ Students will have an understanding of algorithms and algorithmic complexity.
 Syllabi
 --------------------
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp460.rst
+++ b/source/courses/comp460.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp363`
+    * :doc:`comp363`
 
 About
 =====

--- a/source/courses/comp462.rst
+++ b/source/courses/comp462.rst
@@ -49,4 +49,4 @@ Students gain an understanding of the design of the memory hierarchy in modern d
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp462.rst
+++ b/source/courses/comp462.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264` or :doc:`../courses/comp362` or comparable background, including **but not limited to** the following:
+    * :doc:`comp264` or :doc:`comp362` or comparable background, including **but not limited to** the following:
         * Understanding of basic computer organization, including familiarity with such components as CPU, ALU, multiplexers, registers, main memory, caches, and buses,
         * Familiarity with the roles of compilers, assemblers, and operating systems,
         * Some familiarity with assembly language

--- a/source/courses/comp464.rst
+++ b/source/courses/comp464.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp313`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp464.rst
+++ b/source/courses/comp464.rst
@@ -44,4 +44,4 @@ This course will use a blend of foundational understanding as well as a set of p
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp470.rst
+++ b/source/courses/comp470.rst
@@ -45,4 +45,4 @@ Students will be able to perform rigorous testing techniques that contribute to 
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp470.rst
+++ b/source/courses/comp470.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271` or permission of Instructor.
+    * :doc:`comp271` or permission of Instructor.
 
 About
 =====

--- a/source/courses/comp471.rst
+++ b/source/courses/comp471.rst
@@ -45,4 +45,4 @@ An understanding of key principles and paradigms underlying the design and imple
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp471.rst
+++ b/source/courses/comp471.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp413`
+    * :doc:`comp413`
 
 About
 =====

--- a/source/courses/comp472.rst
+++ b/source/courses/comp472.rst
@@ -24,8 +24,8 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp264`
-    * :doc:`../courses/comp313`
+    * :doc:`comp264`
+    * :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp472.rst
+++ b/source/courses/comp472.rst
@@ -46,4 +46,4 @@ Students will learn the theory and practice of how to build a compiler.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp473.rst
+++ b/source/courses/comp473.rst
@@ -68,4 +68,4 @@ Students will have an understanding of Design Patterns, Implementations, and Com
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp473.rst
+++ b/source/courses/comp473.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp413` or :doc:`../courses/comp313`
+    * :doc:`comp413` or :doc:`comp313`
 
 About
 =====

--- a/source/courses/comp474.rst
+++ b/source/courses/comp474.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp474.rst
+++ b/source/courses/comp474.rst
@@ -45,4 +45,4 @@ Students will have a project that they created using Software Enginering practic
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp475.rst
+++ b/source/courses/comp475.rst
@@ -46,4 +46,4 @@ An understanding of the standards that influence world-wide growth of technology
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp476.rst
+++ b/source/courses/comp476.rst
@@ -48,4 +48,4 @@ The course will cover a majority of the following topics: regular languages, fin
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp476.rst
+++ b/source/courses/comp476.rst
@@ -25,7 +25,7 @@ Course Information
     **Prerequisites**
 
     * One or more of the following:
-        * :doc:`../courses/comp163`
+        * :doc:`comp163`
         * |math201|
         * |math212|
 

--- a/source/courses/comp477.rst
+++ b/source/courses/comp477.rst
@@ -45,4 +45,4 @@ The investigation requires the application of project-management tools covered i
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp477.rst
+++ b/source/courses/comp477.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp479.rst
+++ b/source/courses/comp479.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
     * |math131| or |math161|
     * One or more of the following:
         * |stat103|

--- a/source/courses/comp479.rst
+++ b/source/courses/comp479.rst
@@ -49,4 +49,4 @@ Students in this course will learn how to apply sophisticated algorithms to larg
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp480.rst
+++ b/source/courses/comp480.rst
@@ -44,4 +44,4 @@ Understanding of the role of operations management in organizations, and the abi
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp480.rst
+++ b/source/courses/comp480.rst
@@ -23,7 +23,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp484.rst
+++ b/source/courses/comp484.rst
@@ -43,4 +43,4 @@ The student will learn the theory of artificial intelligence and be able to buil
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp484.rst
+++ b/source/courses/comp484.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
 
 About
 =====

--- a/source/courses/comp487.rst
+++ b/source/courses/comp487.rst
@@ -22,7 +22,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp379` or :doc:`../courses/comp479`
+    * :doc:`comp379` or :doc:`comp479`
     * Coursework in basic calculus, statistics, and linear algebra
 
 About

--- a/source/courses/comp487.rst
+++ b/source/courses/comp487.rst
@@ -33,8 +33,8 @@ This course will cover techniques involved in deep learning.
 Description
 ===========
 
- 	
-Deep learning is part of a broader family of machine learning methods based on artificial neural networks. This course will include key concepts of neural network algorithms as well as their applications in computer vision and natural language processing. The topics will include popular building blocks of neural networks including fully-connected, convolutional, recurrent, and transformer layers. 
+
+Deep learning is part of a broader family of machine learning methods based on artificial neural networks. This course will include key concepts of neural network algorithms as well as their applications in computer vision and natural language processing. The topics will include popular building blocks of neural networks including fully-connected, convolutional, recurrent, and transformer layers.
 
 Outcome
 =======
@@ -51,4 +51,4 @@ Students will:
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp488.rst
+++ b/source/courses/comp488.rst
@@ -60,4 +60,4 @@ Students will have an understand of an emerging area of Computer Science.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp488.rst
+++ b/source/courses/comp488.rst
@@ -24,7 +24,7 @@ Course Information
 
     **Prerequisites**
 
-    * :doc:`../courses/comp271`
+    * :doc:`comp271`
     * Section specific requirements
 
 About

--- a/source/courses/comp490.rst
+++ b/source/courses/comp490.rst
@@ -45,4 +45,4 @@ The student will conduct research on a project with the support of Loyola facult
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp499.rst
+++ b/source/courses/comp499.rst
@@ -43,4 +43,4 @@ The student will have real world experience of working within the industry of th
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/comp605.rst
+++ b/source/courses/comp605.rst
@@ -43,4 +43,4 @@ Students will be able to pursue their Master of Science education while not bein
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/isscm349.rst
+++ b/source/courses/isscm349.rst
@@ -44,4 +44,4 @@ Students will have a business understaning of project management.
 Syllabi
 *******
 
-See :doc:`../syllabi/syllabi`.
+|see-syllabi|

--- a/source/courses/isscm349.rst
+++ b/source/courses/isscm349.rst
@@ -22,8 +22,8 @@ Course Information
     **Prerequisites**
 
     * Junior Standing
-    * `ACCT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainaccounting/#692265>`_
-    * `MGMT 201 <https://www.luc.edu/quinlan/academics/undergraduatedegrees/bba/bbainmanagement/#675009>`_
+    * |acct201|
+    * |mgmt201|
 
 About
 =====

--- a/source/courses/undergraduate-courses.rst
+++ b/source/courses/undergraduate-courses.rst
@@ -14,7 +14,7 @@ Undergraduate Courses
 
 .. important::
 
-    Some course prereqs and other details are in transition, and you may see details that are slightly past or slightly futuristic. You can look in `Locus <https://locus.luc.edu>`_ to see what is in force at the moment, and you can inquire about the possibility of overriding certain prereqs during the transition period.
+    Some course prereqs and other details are in transition, and you may see details that are slightly past or slightly futuristic. You can look in |locus|  to see what is in force at the moment, and you can inquire about the possibility of overriding certain prereqs during the transition period.
 
 *****************
 100 Level Courses

--- a/source/courses/undergraduate-courses.rst
+++ b/source/courses/undergraduate-courses.rst
@@ -14,7 +14,7 @@ Undergraduate Courses
 
 .. important::
 
-    Some course prereqs and other details are in transition, and you may see details that are slightly past or slightly futuristic. You can look in |locus|  to see what is in force at the moment, and you can inquire about the possibility of overriding certain prereqs during the transition period.
+    Some course prereqs and other details are in transition, and you may see details that are slightly past or slightly futuristic. You can look in |short-locus|  to see what is in force at the moment, and you can inquire about the possibility of overriding certain prereqs during the transition period.
 
 *****************
 100 Level Courses

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,31 +14,31 @@ This site is aimed at helping *current* students find detailed information about
 
 .. note::
 
-   See the main `Computer Science Department`_ web site for general program information and how to *apply* for admission to our undergraduate and graduate programs, including our professional certificate programs.
+    See the main `Computer Science Department`_ web site for general program information and how to *apply* for admission to our undergraduate and graduate programs, including our professional certificate programs.
 
 Schedules and Syllabi
 ---------------------
 
 .. note::
 
-   |see-locus|
+    |see-locus|
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   schedules/schedules
-   syllabi/syllabi
-   syllabi/legacy-syllabi
+    schedules/schedules
+    syllabi/syllabi
+    syllabi/legacy-syllabi
 
 
 Undergraduate Student Resources
 -------------------------------
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   courses/undergraduate-courses
-   undergraduate/undergraduate-degree-programs
+    courses/undergraduate-courses
+    undergraduate/undergraduate-degree-programs
 
 Graduate Student Resources
 --------------------------

--- a/source/schedules/schedules.rst
+++ b/source/schedules/schedules.rst
@@ -2,7 +2,7 @@ Course Schedules / Information
 ==============================
 
 .. note::
-    Visitors are expected to use `Locus <https://locus.luc.edu>`_ to see authoritative course schedule information. The links below also can be used for additional informal information.
+    Visitors are expected to use `LOCUS <https://locus.luc.edu>`_ to see authoritative course schedule information. The links below also can be used for additional informal information.
 
 Long Term Schedule
 ------------------

--- a/source/undergraduate/bsmsprograms.rst
+++ b/source/undergraduate/bsmsprograms.rst
@@ -42,7 +42,7 @@ The academic prerequisites to be considered for admission to the BS/MS programs 
 -   Satisfactory progress towards completion of Loyola’s core.
 
 .. important::
-    Before the undergraduate deadlines do apply to graduate with your B.S in the semester you will actually finish! Otherwise, you complicate the conversion to graduate status. If the date when you will start graduate status changes from your original application, notify the GPD ahead of time so data in Locus can be fixed.
+    Before the undergraduate deadlines do apply to graduate with your B.S in the semester you will actually finish! Otherwise, you complicate the conversion to graduate status. If the date when you will start graduate status changes from your original application, notify the GPD ahead of time so data in LOCUS can be fixed.
 
 .. _application_information:
 


### PR DESCRIPTION
Replaced all class hard links with definitions defined in the `rst_epilog` string in `./source/conf.py`.

Also made sure that LOCUS is spelled properly based off of Loyola's spelling of the word.